### PR TITLE
Fix 500 error and test wp-plugin

### DIFF
--- a/.github/workflows/nightly-docker-integration-tests.yml
+++ b/.github/workflows/nightly-docker-integration-tests.yml
@@ -1,0 +1,92 @@
+name: Nightly Docker Integration Tests
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      wordpress-branch:
+        description: 'Branch for pipeline-wordpress'
+        required: false
+        default: 'main'
+      cloudrequestengine-branch:
+        description: 'Branch for pipeline-php-cloudrequestengine'
+        required: false
+        default: 'main'
+      engines-branch:
+        description: 'Branch for pipeline-php-engines'
+        required: false
+        default: 'main'
+      core-branch:
+        description: 'Branch for pipeline-php-core'
+        required: false
+        default: 'main'
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout pipeline-wordpress
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/pipeline-wordpress
+          ref: ${{ inputs.wordpress-branch || 'main' }}
+          path: pipeline-wordpress
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Checkout pipeline-php-cloudrequestengine
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/pipeline-php-cloudrequestengine
+          ref: ${{ inputs.cloudrequestengine-branch || 'main' }}
+          path: pipeline-php-cloudrequestengine
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Checkout pipeline-php-engines
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/pipeline-php-engines
+          ref: ${{ inputs.engines-branch || 'main' }}
+          path: pipeline-php-engines
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Checkout pipeline-php-core
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/pipeline-php-core
+          ref: ${{ inputs.core-branch || 'main' }}
+          path: pipeline-php-core
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Configure local dependencies
+        working-directory: pipeline-wordpress
+        run: ./ci/configure-local-deps.ps1
+
+      - name: Install Composer dependencies
+        working-directory: pipeline-wordpress/lib
+        run: composer update --no-interaction
+
+      - name: Start Docker environment
+        working-directory: pipeline-wordpress
+        run: docker compose -f ci/docker-compose.test.yml up -d
+
+      - name: Run integration tests
+        working-directory: pipeline-wordpress
+        env:
+          SUPER_RESOURCE_KEY: ${{ secrets.SUPER_RESOURCE_KEY }}
+        run: ./ci/run-docker-tests.ps1
+
+      - name: Tear down Docker environment
+        if: always()
+        working-directory: pipeline-wordpress
+        run: docker compose -f ci/docker-compose.test.yml down

--- a/ci/configure-local-deps.ps1
+++ b/ci/configure-local-deps.ps1
@@ -1,0 +1,54 @@
+# Configure Composer path repositories for local cross-repo dependencies.
+#
+# This script registers sibling repos as Composer path repositories with
+# version overrides so that branches (e.g. fix/issue-33) satisfy the "4.*"
+# constraint in composer.json. symlink is set to false so that dependencies
+# are mirrored (copied) into lib/vendor/ instead of symlinked — this is
+# required for the Docker bind mount to work correctly.
+
+Push-Location "$PSScriptRoot/../lib"
+
+try {
+    $repos = @(
+        @{
+            Name    = "local-core"
+            Url     = "../../pipeline-php-core"
+            Package = "51degrees/fiftyone.pipeline.core"
+        },
+        @{
+            Name    = "local-engines"
+            Url     = "../../pipeline-php-engines"
+            Package = "51degrees/fiftyone.pipeline.engines"
+        },
+        @{
+            Name    = "local-cloudrequestengine"
+            Url     = "../../pipeline-php-cloudrequestengine"
+            Package = "51degrees/fiftyone.pipeline.cloudrequestengine"
+        }
+    )
+
+    foreach ($repo in $repos) {
+        $json = @{
+            type    = "path"
+            url     = $repo.Url
+            options = @{
+                versions = @{
+                    $repo.Package = "4.99.99"
+                }
+                symlink = $false
+            }
+        } | ConvertTo-Json -Depth 4 -Compress
+
+        Write-Output "Configuring path repository: $($repo.Name) -> $($repo.Url)"
+        composer config "repositories.$($repo.Name)" --json $json
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to configure repository $($repo.Name)"
+        }
+    }
+
+    Write-Output "All path repositories configured successfully."
+    composer config --list | Select-String "repositories"
+}
+finally {
+    Pop-Location
+}

--- a/ci/docker-compose.test.yml
+++ b/ci/docker-compose.test.yml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: mariadb:lts
+    command: '--default-authentication-plugin=mysql_native_password'
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    healthcheck:
+      test: healthcheck.sh --connect --innodb_initialized
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  wordpress:
+    image: wordpress:php8.2-apache
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ../:/var/www/html/wp-content/plugins/fiftyonedegrees
+
+volumes:
+  db_data:

--- a/ci/run-docker-tests.ps1
+++ b/ci/run-docker-tests.ps1
@@ -1,0 +1,187 @@
+# End-to-end integration tests against a running WordPress Docker environment.
+#
+# Prerequisites:
+#   - docker compose services (wordpress + db) are running
+#   - SUPER_RESOURCE_KEY environment variable is set
+#
+# Tests:
+#   1. Plugin activates successfully
+#   2. Settings page loads (HTTP 200)
+#   3. REST endpoint responds (HTTP 200)
+#   4. Device detection JavaScript is injected into page output
+
+$ErrorActionPreference = "Stop"
+
+if (-not $env:SUPER_RESOURCE_KEY) {
+    Write-Output "::warning::No SUPER_RESOURCE_KEY provided, skipping Docker integration tests."
+    exit 0
+}
+
+$baseUrl = "http://localhost:8080"
+$composeFile = "$PSScriptRoot/docker-compose.test.yml"
+$failed = 0
+$passed = 0
+
+function Test-Check {
+    param(
+        [string]$Name,
+        [scriptblock]$Check
+    )
+
+    try {
+        $result = & $Check
+        if ($result) {
+            Write-Output "  PASS: $Name"
+            $script:passed++
+        }
+        else {
+            Write-Output "  FAIL: $Name"
+            $script:failed++
+        }
+    }
+    catch {
+        Write-Output "  FAIL: $Name - $_"
+        $script:failed++
+    }
+}
+
+# --- Wait for WordPress to respond ---
+
+Write-Output "Waiting for WordPress to be ready..."
+$maxRetries = 30
+$retryInterval = 5
+
+for ($i = 0; $i -lt $maxRetries; $i++) {
+    try {
+        $response = Invoke-WebRequest -Uri $baseUrl -UseBasicParsing -TimeoutSec 5 -ErrorAction SilentlyContinue
+        if ($response.StatusCode -eq 200 -or $response.StatusCode -eq 302) {
+            Write-Output "WordPress is ready."
+            break
+        }
+    }
+    catch {
+        # Not ready yet
+    }
+
+    if ($i -eq ($maxRetries - 1)) {
+        Write-Error "WordPress did not become ready within $($maxRetries * $retryInterval) seconds."
+        exit 1
+    }
+
+    Write-Output "  Retrying in $retryInterval seconds... ($($i + 1)/$maxRetries)"
+    Start-Sleep -Seconds $retryInterval
+}
+
+# --- Install WP-CLI inside the container ---
+
+Write-Output "Installing WP-CLI..."
+docker compose -f $composeFile exec -T wordpress bash -c "curl -sO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/local/bin/wp"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install WP-CLI."
+    exit 1
+}
+
+# --- Install WordPress ---
+
+Write-Output "Installing WordPress..."
+docker compose -f $composeFile exec -T wordpress wp core install `
+    --url="$baseUrl" `
+    --title="51Degrees Test Site" `
+    --admin_user="admin" `
+    --admin_password="admin" `
+    --admin_email="test@example.com" `
+    --skip-email `
+    --allow-root
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install WordPress."
+    exit 1
+}
+
+# --- Activate the plugin ---
+
+Write-Output "Activating 51Degrees plugin..."
+docker compose -f $composeFile exec -T wordpress wp plugin activate fiftyonedegrees --allow-root
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to activate plugin."
+    exit 1
+}
+
+# --- Configure the resource key and build the pipeline ---
+#
+# wp option update on a new option internally calls add_option(), which fires
+# add_option action — NOT update_option. The plugin's pipeline-build hook is
+# on update_option, so it would not trigger. Instead, we use wp eval to set
+# the resource key and explicitly build the pipeline.
+
+Write-Output "Configuring resource key and building pipeline..."
+$resourceKey = $env:SUPER_RESOURCE_KEY
+docker compose -f $composeFile exec -T wordpress wp eval @"
+`$key = '$resourceKey';
+update_option('fiftyonedegrees_resource_key', `$key);
+`$pipeline = Pipeline::make_pipeline(`$key);
+if (`$pipeline['error']) {
+    fwrite(STDERR, 'Pipeline build error: ' . `$pipeline['error'] . PHP_EOL);
+    exit(1);
+}
+update_option('fiftyonedegrees_resource_key_pipeline', `$pipeline);
+echo 'Pipeline built. Engines: ' . implode(', ', `$pipeline['available_engines']) . PHP_EOL;
+"@ --allow-root
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to configure resource key and build pipeline."
+    exit 1
+}
+
+# --- Run verification tests ---
+#
+# Tests use curl from the host (port 8080) rather than from inside the
+# container (port 80) because WordPress redirects internal requests to the
+# configured site URL (localhost:8080).
+
+Write-Output ""
+Write-Output "Running verification tests..."
+
+# Test 1: Plugin is active
+Test-Check "Plugin is listed as active" {
+    $output = docker compose -f $composeFile exec -T wordpress wp plugin list --status=active --field=name --allow-root
+    $output -match "fiftyonedegrees"
+}
+
+# Test 2: Admin settings page loads
+Test-Check "Settings page loads (HTTP 200)" {
+    $response = Invoke-WebRequest -Uri "$baseUrl/wp-login.php" `
+        -Method POST `
+        -Body @{ log = "admin"; pwd = "admin"; "wp-submit" = "Log In"; redirect_to = "/wp-admin/" } `
+        -SessionVariable session `
+        -UseBasicParsing
+    $settingsPage = Invoke-WebRequest -Uri "$baseUrl/wp-admin/options-general.php?page=51Degrees" `
+        -WebSession $session `
+        -UseBasicParsing
+    $settingsPage.StatusCode -eq 200
+}
+
+# Test 3: REST endpoint responds
+Test-Check "REST endpoint responds (HTTP 200)" {
+    $response = Invoke-WebRequest -Uri "$baseUrl/wp-json/fiftyonedegrees/v4/json" `
+        -Method POST `
+        -UseBasicParsing
+    $response.StatusCode -eq 200
+}
+
+# Test 4: Device detection JavaScript is injected
+Test-Check "51Degrees JavaScript snippet is injected into page" {
+    $response = Invoke-WebRequest -Uri "$baseUrl/" `
+        -Headers @{ "User-Agent" = "Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.120 Mobile Safari/537.36" } `
+        -UseBasicParsing
+    $response.Content -match "fiftyonedegrees-js-before"
+}
+
+# --- Report results ---
+
+Write-Output ""
+Write-Output "============================================"
+Write-Output "Results: $passed passed, $failed failed"
+Write-Output "============================================"
+
+if ($failed -gt 0) {
+    exit 1
+}

--- a/includes/pipeline.php
+++ b/includes/pipeline.php
@@ -76,6 +76,8 @@ class Pipeline
 
         try {
             $cloud = new CloudRequestEngine(['resourceKey' => $resourceKey]);
+            // Get engines available with the Resource Key
+            $engines = array_keys($cloud->getEngineProperties());
         } catch (Exception $e) {
             $error = $e->getMessage();
 
@@ -85,9 +87,6 @@ class Pipeline
                 'error' => $error
             ];
         }
-
-        // Get engines available with the Resource Key
-        $engines = array_keys($cloud->flowElementProperties);
 
         // Add CloudRequestEngine to the pipeline.
         $builder->add($cloud);

--- a/tests/PipelineTests.php
+++ b/tests/PipelineTests.php
@@ -88,7 +88,7 @@ class PipelineTests extends TestCase {
 
     /**
      * Test that an invalid Resource Key results in an error being added to the
-     * pipeline.
+     * pipeline result and process() handling it gracefully.
      */
     public function testMakePipeline_InValidResourceKey() {
 
@@ -98,19 +98,20 @@ class PipelineTests extends TestCase {
         $resourceKey = "XXXXXXXXXXXXXX";
         $result = Pipeline::make_pipeline($resourceKey);
 
+        // make_pipeline should catch the error and return it in the result
+        $this->assertNull($result['pipeline']);
+        $this->assertNull($result['available_engines']);
+        $this->assertNotNull($result['error']);
+        $this->assertStringContainsString('XXXXXXXXXXXXXX', $result['error']);
+
         Functions\expect('get_option')
             ->once()
             ->with(Options::PIPELINE)
             ->andReturn($result);
 
-        $errorMessage = "Error returned from 51Degrees cloud service: ''XXXXXXXXXXXXXX' " .
-            "is not a valid Resource Key. See " .
-            "http://51degrees.com/documentation/_info__error_messages.html#Resource_key_not_valid " .
-            "for more information.'";
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage($errorMessage);
+        // process() should handle the error gracefully (log and return)
         Pipeline::process();
+        $this->assertNull(Pipeline::$data);
     }
 
     /**


### PR DESCRIPTION
- Depends on: https://github.com/51Degrees/pipeline-php-cloudrequestengine/pull/45
- Eagerly call `getEngineProperties()` to see what properties available and thus what engines we need in the pipeline to read those properties - this fixes the 500 crash we had 
- Create docker compose build and integration tests exercising that build
- Fixes: https://github.com/51Degrees/pipeline-wordpress/issues/33