### PR TITLE
Add suspicious activity detection feature

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -18,15 +18,10 @@
     clause in Article 5 of the EUPL shall not apply.
 */
 
-    if (isset($_GET["tab"])) {
-
-        $active_tab = sanitize_text_field( $_GET["tab"] );
-    
-    } else {
-
-        $active_tab = "setup";
-
-    }
+    $valid_tabs = ['setup', 'google-analytics', 'properties', 'help', 'suspicious'];
+    $active_tab = isset($_GET['tab']) && in_array($_GET['tab'], $valid_tabs, true)
+        ? $_GET['tab']
+        : 'setup';
 
 ?>
 
@@ -34,7 +29,8 @@
     <a href="?page=51Degrees&tab=setup" class="nav-tab <?php echo $active_tab == 'setup' ? 'nav-tab-active' : ''; ?>">Setup</a>
     <a href="?page=51Degrees&tab=google-analytics" class="nav-tab <?php echo $active_tab == 'google-analytics' ? 'nav-tab-active' : ''; ?>" style="<?php echo !get_option(Options::RESOURCE_KEY) ? 'pointer-events:none;color:#C0C0C0;' : ''; ?>">Google Analytics</a>
 	
-    <a href="?page=51Degrees&tab=properties" class="nav-tab <?php echo $active_tab == 'properties' ? 'nav-tab-active' : '';  ?>" style="<?php echo !get_option(Options::RESOURCE_KEY) ? 'pointer-events:none;color:#C0C0C0;' : ''; ?>">Properties</a>	
+    <a href="?page=51Degrees&tab=properties" class="nav-tab <?php echo $active_tab == 'properties' ? 'nav-tab-active' : '';  ?>" style="<?php echo !get_option(Options::RESOURCE_KEY) ? 'pointer-events:none;color:#C0C0C0;' : ''; ?>">Properties</a>
+    <a href="?page=51Degrees&tab=suspicious" class="nav-tab <?php echo $active_tab == 'suspicious' ? 'nav-tab-active' : ''; ?>" style="<?php echo !get_option(Options::RESOURCE_KEY) ? 'pointer-events:none;color:#C0C0C0;' : ''; ?>"><?php esc_html_e('Suspicious', '51D'); ?></a>
     <a href="?page=51Degrees&tab=help" class="nav-tab <?php echo $active_tab == 'help' ? 'nav-tab-active' : ''; ?>">Help</a>
 </h2>
                   

--- a/ci/integration-tests/test_suspicious_activity.py
+++ b/ci/integration-tests/test_suspicious_activity.py
@@ -1,0 +1,234 @@
+"""Selenium tests: verify suspicious activity detection feature.
+
+Tests the admin UI settings form, checkbox state persistence,
+threshold-based redirect, disabled-feature behavior, and admin
+lockout prevention.
+"""
+
+import re
+import time
+
+import pytest
+import requests
+
+from conftest import WORDPRESS_URL, ADMIN_USER, ADMIN_PASS
+
+
+def get_admin_nonce(session, tab_url):
+    """Extract the _wpnonce from a 51Degrees settings tab."""
+    resp = session.get(tab_url)
+    resp.raise_for_status()
+    match = re.search(r'name="_wpnonce"\s+value="([^"]+)"', resp.text)
+    assert match, 'Could not extract _wpnonce from settings page'
+    return match.group(1), resp.text
+
+
+def save_suspicious_settings(session, enable='off', redirect_url='',
+                             requests_count=5, window=30):
+    """Save suspicious activity settings via the admin form."""
+    base = WORDPRESS_URL.rstrip('/')
+    tab_url = base + '/wp-admin/options-general.php?page=51Degrees&tab=suspicious'
+    nonce, _ = get_admin_nonce(session, tab_url)
+
+    data = {
+        '_wpnonce': nonce,
+        '_wp_http_referer': '/wp-admin/options-general.php?page=51Degrees&tab=suspicious',
+        'option_page': 'fiftyonedegrees_suspicious_options',
+        'action': 'update',
+        'fiftyonedegrees_suspicious_enable': enable,
+        'fiftyonedegrees_suspicious_redirect_url': redirect_url,
+        'fiftyonedegrees_suspicious_requests': str(requests_count),
+        'fiftyonedegrees_suspicious_window': str(window),
+    }
+
+    resp = session.post(base + '/wp-admin/options.php', data=data,
+                        allow_redirects=False)
+    assert resp.status_code in (200, 302), (
+        f'Settings save returned {resp.status_code}'
+    )
+
+
+def create_page(session, title, slug):
+    """Create a WordPress page via the REST API and return its permalink."""
+    base = WORDPRESS_URL.rstrip('/')
+
+    # Get a REST nonce from the admin page
+    resp = session.get(base + '/wp-admin/')
+    resp.raise_for_status()
+    match = re.search(r'"_wpnonce":"([^"]+)"', resp.text)
+    if not match:
+        match = re.search(r'wpApiSettings.*?"nonce":"([^"]+)"', resp.text)
+    assert match, 'Could not extract REST nonce'
+    rest_nonce = match.group(1)
+
+    resp = session.post(
+        base + '/wp-json/wp/v2/pages',
+        json={'title': title, 'slug': slug, 'status': 'publish'},
+        headers={'X-WP-Nonce': rest_nonce},
+    )
+    assert resp.status_code == 201, (
+        f'Page creation returned {resp.status_code}: {resp.text[:200]}'
+    )
+    page_data = resp.json()
+    return page_data['id'], page_data['link']
+
+
+def delete_page(session, page_id):
+    """Delete a WordPress page via the REST API."""
+    base = WORDPRESS_URL.rstrip('/')
+
+    resp = session.get(base + '/wp-admin/')
+    match = re.search(r'"_wpnonce":"([^"]+)"', resp.text)
+    if not match:
+        match = re.search(r'wpApiSettings.*?"nonce":"([^"]+)"', resp.text)
+    if match:
+        rest_nonce = match.group(1)
+        session.delete(
+            base + f'/wp-json/wp/v2/pages/{page_id}?force=true',
+            headers={'X-WP-Nonce': rest_nonce},
+        )
+
+
+class TestSettingsFormRoundTrip:
+    """Test #1: Settings form saves and restores all four values."""
+
+    def test_settings_round_trip(self, wp_admin_session):
+        session = wp_admin_session
+        base = WORDPRESS_URL.rstrip('/')
+        tab_url = base + '/wp-admin/options-general.php?page=51Degrees&tab=suspicious'
+
+        try:
+            save_suspicious_settings(
+                session, enable='on',
+                redirect_url='http://localhost:8080/blocked/',
+                requests_count=7, window=45,
+            )
+
+            _, html = get_admin_nonce(session, tab_url)
+
+            assert 'value="on"' in html and 'checked' in html
+            assert 'http://localhost:8080/blocked/' in html
+            assert 'value="7"' in html
+            assert 'value="45"' in html
+        finally:
+            save_suspicious_settings(session)
+
+
+class TestCheckboxUncheckedState:
+    """Test #2: Unchecking the checkbox persists as 'off'."""
+
+    def test_checkbox_unchecked_disables(self, wp_admin_session):
+        session = wp_admin_session
+        base = WORDPRESS_URL.rstrip('/')
+        tab_url = base + '/wp-admin/options-general.php?page=51Degrees&tab=suspicious'
+
+        try:
+            save_suspicious_settings(session, enable='on')
+            _, html = get_admin_nonce(session, tab_url)
+            assert 'checked' in html
+
+            save_suspicious_settings(session, enable='off')
+            _, html = get_admin_nonce(session, tab_url)
+            assert 'checked=\'checked\'' not in html
+            assert 'checked="checked"' not in html
+        finally:
+            save_suspicious_settings(session)
+
+
+class TestThresholdRedirect:
+    """Test #3: Visitors are redirected after reaching the threshold."""
+
+    def test_threshold_redirect(self, wp_admin_session, browser):
+        session = wp_admin_session
+        base = WORDPRESS_URL.rstrip('/')
+        page_id = None
+
+        try:
+            page_id, permalink = create_page(session, 'Blocked', 'blocked')
+
+            save_suspicious_settings(
+                session, enable='on', redirect_url=permalink,
+                requests_count=3, window=60,
+            )
+
+            browser.delete_all_cookies()
+
+            for i in range(3):
+                browser.get(base + '/')
+                time.sleep(0.5)
+
+            current = browser.current_url.rstrip('/')
+            blocked_path = permalink.rstrip('/')
+            assert blocked_path in current or 'blocked' in current.lower(), (
+                f'Expected redirect to {permalink}, got {browser.current_url}'
+            )
+        finally:
+            save_suspicious_settings(session)
+            if page_id:
+                delete_page(session, page_id)
+
+
+class TestNoRedirectWhenDisabled:
+    """Test #4: No redirect when the feature is disabled."""
+
+    def test_no_redirect_when_disabled(self, wp_admin_session, browser):
+        session = wp_admin_session
+        base = WORDPRESS_URL.rstrip('/')
+
+        try:
+            save_suspicious_settings(session, enable='off')
+
+            browser.delete_all_cookies()
+
+            for _ in range(10):
+                browser.get(base + '/')
+                time.sleep(0.3)
+
+            assert '/wp-login' not in browser.current_url
+            assert 'blocked' not in browser.current_url.lower()
+        finally:
+            save_suspicious_settings(session)
+
+
+class TestAdminLockoutPrevention:
+    """Test #5: Admin pages are never redirected."""
+
+    def test_admin_not_locked_out(self, wp_admin_session, browser):
+        session = wp_admin_session
+        base = WORDPRESS_URL.rstrip('/')
+        page_id = None
+
+        try:
+            page_id, permalink = create_page(
+                session, 'Blocked Admin', 'blocked-admin'
+            )
+
+            save_suspicious_settings(
+                session, enable='on', redirect_url=permalink,
+                requests_count=3, window=60,
+            )
+
+            # Log in via the browser
+            browser.delete_all_cookies()
+            browser.get(base + '/wp-login.php')
+            browser.find_element('id', 'user_login').send_keys(ADMIN_USER)
+            browser.find_element('id', 'user_pass').send_keys(ADMIN_PASS)
+            browser.find_element('id', 'wp-submit').click()
+            time.sleep(2)
+
+            # Trip the counter on the frontend
+            for _ in range(4):
+                browser.get(base + '/')
+                time.sleep(0.3)
+
+            # Navigate to admin — should NOT be redirected
+            browser.get(base + '/wp-admin/')
+            time.sleep(1)
+
+            assert '/wp-admin' in browser.current_url, (
+                f'Admin was redirected to {browser.current_url}'
+            )
+        finally:
+            save_suspicious_settings(session)
+            if page_id:
+                delete_page(session, page_id)

--- a/fiftyonedegrees.php
+++ b/fiftyonedegrees.php
@@ -126,6 +126,7 @@ class Fiftyonedegrees {
         require_once __DIR__ . '/includes/ga-service.php';
         require_once __DIR__ . '/includes/ga-tracking-gtag.php';
         require_once __DIR__ . '/options.php';
+        require_once __DIR__ . '/includes/suspicious-activity.php';
         
         // Include Custom_Dimensions class
         if (!class_exists('Fiftyonedegrees_Custom_Dimensions')) {

--- a/includes/fiftyone-service.php
+++ b/includes/fiftyone-service.php
@@ -171,6 +171,33 @@ class FiftyoneService {
         register_setting(
             Options::GROUP_KEY,
             Options::RESOURCE_KEY);
+
+        // Suspicious activity detection settings.
+        add_option(Options::SUSPICIOUS_ENABLE, 'off');
+        add_option(Options::SUSPICIOUS_REDIRECT_URL, '');
+        add_option(Options::SUSPICIOUS_REQUESTS, 5);
+        add_option(Options::SUSPICIOUS_WINDOW, 30);
+
+        register_setting(Options::SUSPICIOUS_GROUP_KEY, Options::SUSPICIOUS_ENABLE, [
+            'type' => 'string',
+            'sanitize_callback' => function ($v) { return $v === 'on' ? 'on' : 'off'; },
+            'default' => 'off',
+        ]);
+        register_setting(Options::SUSPICIOUS_GROUP_KEY, Options::SUSPICIOUS_REDIRECT_URL, [
+            'type' => 'string',
+            'sanitize_callback' => 'esc_url_raw',
+            'default' => '',
+        ]);
+        register_setting(Options::SUSPICIOUS_GROUP_KEY, Options::SUSPICIOUS_REQUESTS, [
+            'type' => 'integer',
+            'sanitize_callback' => function ($v) { return max(1, (int) $v); },
+            'default' => 5,
+        ]);
+        register_setting(Options::SUSPICIOUS_GROUP_KEY, Options::SUSPICIOUS_WINDOW, [
+            'type' => 'integer',
+            'sanitize_callback' => function ($v) { return max(1, min(3600, (int) $v)); },
+            'default' => 30,
+        ]);
     }
 
     /**
@@ -279,6 +306,10 @@ class FiftyoneService {
                 delete_option(Options::RESOURCE_KEY_UPDATED);
             }
             
+        }
+
+        if ($option === Options::SUSPICIOUS_ENABLE && $new_value === 'on' && $old_value !== 'on') {
+            update_option(Options::SESSION_INVALIDATED, time());
         }
 
         if ($option === Options::GA_TRACKING_ID &&

--- a/includes/pipeline.php
+++ b/includes/pipeline.php
@@ -152,6 +152,12 @@ class Pipeline
             // Set evidence from web request.
             $flowData->evidence->setFromWebRequest();
 
+            // Suspicious activity detection relies on IdProbLic/IdProbGlobal;
+            // the cloud requires query.id.usage for those to be populated.
+            if (get_option(Options::SUSPICIOUS_ENABLE, 'off') === 'on') {
+                $flowData->evidence->set('query.id.usage', 'non-marketing');
+            }
+
             // Process flowData with evidence supplied
             try {
                 $flowData->process();

--- a/includes/suspicious-activity.php
+++ b/includes/suspicious-activity.php
@@ -1,0 +1,329 @@
+<?php
+/*
+    This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+    Copyright 2019 51 Degrees Mobile Experts Limited, 5 Charlotte Close,
+    Caversham, Reading, Berkshire, United Kingdom RG4 7BY.
+
+    This Original Work is licensed under the European Union Public Licence (EUPL)
+    v.1.2 and is subject to its terms as set out below.
+
+    If a copy of the EUPL was not distributed with this file, You can obtain
+    one at https://opensource.org/licenses/EUPL-1.2.
+
+    The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+    amended by the European Commission) shall be deemed incompatible for
+    the purposes of the Work and the provisions of the compatibility
+    clause in Article 5 of the EUPL shall not apply.
+*/
+
+require_once __DIR__ . '/../options.php';
+
+/**
+ * Suspicious activity detection engine.
+ *
+ * Tracks per-visitor request rates using WordPress transients and
+ * redirects visitors who exceed a configured threshold.
+ *
+
+ */
+class SuspiciousActivity
+{
+    /**
+     * Registers the parse_request hook for suspicious activity checking.
+     * Priority 11 ensures rest_api_loaded (priority 10) runs first: for
+     * REST requests it defines REST_REQUEST and exits, so our hook never
+     * fires for them. For non-REST requests REST_REQUEST remains
+     * undefined, which the exclusion check handles.
+     *
+     * @access public
+     *
+     * @return void
+     */
+    public static function register()
+    {
+        add_action('parse_request', [__CLASS__, 'check_and_maybe_redirect'], 11);
+    }
+
+    /**
+     * Main entry point called on parse_request at priority 11.
+     * Checks exclusions, records the request, and redirects if threshold met.
+     *
+     * @access public
+    
+     * @return void
+     */
+    public static function check_and_maybe_redirect()
+    {
+        if (get_option(Options::SUSPICIOUS_ENABLE, 'off') !== 'on') {
+            return;
+        }
+
+        if (self::is_excluded_context()) {
+            return;
+        }
+
+        $window = (int) get_option(Options::SUSPICIOUS_WINDOW, 30);
+        $threshold = (int) get_option(Options::SUSPICIOUS_REQUESTS, 5);
+
+        if ($window <= 0 || $threshold <= 0) {
+            return;
+        }
+
+        if (self::is_on_redirect_target()) {
+            return;
+        }
+
+        if (headers_sent()) {
+            error_log('Suspicious activity: cannot redirect, headers already sent');
+            return;
+        }
+
+        $did = self::get_51did();
+        $key = self::build_transient_key($did);
+        $now = microtime(true);
+
+        $timestamps = get_transient($key);
+        if (!is_array($timestamps)) {
+            $timestamps = [];
+        }
+
+        // Prune expired entries.
+        $timestamps = array_values(array_filter(
+            $timestamps,
+            function ($t) use ($now, $window) {
+                return $t >= $now - $window;
+            }
+        ));
+
+        $timestamps[] = $now;
+        set_transient($key, $timestamps, $window);
+
+        if (count($timestamps) >= $threshold) {
+            $target = get_option(Options::SUSPICIOUS_REDIRECT_URL);
+            if (!$target) {
+                return;
+            }
+            wp_safe_redirect($target, 302);
+            exit;
+        }
+    }
+
+    /**
+     * Resolves the visitor identity.
+     * Tries IdProbLic then IdProbGlobal from the pipeline, falling back
+     * to a SHA-256 hash of IP + User-Agent.
+     *
+     * @access public
+    
+     * @return string visitor identifier (always returns a value)
+     */
+    public static function get_51did()
+    {
+        $properties = Pipeline::$data['properties'] ?? [];
+
+        foreach (['idproblic', 'idprobglobal'] as $propName) {
+            foreach ($properties as $engine => $props) {
+                if (isset($props[$propName])) {
+                    $value = Pipeline::get($engine, $propName);
+                    if (is_string($value) && $value !== '') {
+                        $identifier = self::extract_owid_identifier($value);
+                        if ($identifier !== null) {
+                            return $identifier;
+                        }
+                    }
+                }
+            }
+        }
+
+        $ip = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '127.0.0.1';
+        $ua = sanitize_text_field(
+            wp_unslash(isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '')
+        );
+        return hash('sha256', $ip . '|' . $ua);
+    }
+
+    /**
+     * Extracts the 32-byte Identifier (bytes 21..52) from a base64-encoded
+     * OWID v3 token and returns it as a 64-char hex string.
+     *
+     * The envelope's ECDSA signature is regenerated on every request
+     * (random nonce), so hashing the full token would produce a new
+     * tracking key per request. The Identifier is the SHA-256 hash the
+     * cloud computed from visitor features and is stable per visitor.
+     *
+     * @access public
+     *
+     * @param  mixed       $token base64-encoded OWID token
+     * @return string|null 64-char hex identifier, or null on malformed input
+     */
+    public static function extract_owid_identifier($token)
+    {
+        if (!is_string($token) || $token === '') {
+            return null;
+        }
+        $normalized = strtr($token, '-_', '+/');
+        $pad = (4 - strlen($normalized) % 4) % 4;
+        $decoded = base64_decode($normalized . str_repeat('=', $pad), true);
+        if (!is_string($decoded) || strlen($decoded) !== 117) {
+            return null;
+        }
+        if (ord($decoded[0]) !== 3) {
+            return null;
+        }
+        return bin2hex(substr($decoded, 21, 32));
+    }
+
+    /**
+     * Finds the engine dataKey that exposes IdProbLic or IdProbGlobal.
+     * Used by the admin UI to display the active tracking mode.
+     *
+     * @access public
+    
+     * @return string|null engine dataKey, or null if not available
+     */
+    public static function id_engine_datakey()
+    {
+        $properties = Pipeline::$data['properties'] ?? [];
+        foreach ($properties as $engine => $props) {
+            if (isset($props['idproblic']) || isset($props['idprobglobal'])) {
+                return $engine;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Records a request timestamp and returns the new count within the window.
+     *
+     * @access public
+    
+     * @param  string $did   visitor identifier
+     * @return int    number of requests in the current window
+     */
+    public static function record_request($did)
+    {
+        $key = self::build_transient_key($did);
+        $window = (int) get_option(Options::SUSPICIOUS_WINDOW, 30);
+        $now = microtime(true);
+
+        $timestamps = get_transient($key);
+        if (!is_array($timestamps)) {
+            $timestamps = [];
+        }
+
+        $timestamps = array_values(array_filter(
+            $timestamps,
+            function ($t) use ($now, $window) {
+                return $t >= $now - $window;
+            }
+        ));
+
+        $timestamps[] = $now;
+        set_transient($key, $timestamps, $window);
+
+        return count($timestamps);
+    }
+
+    /**
+     * Builds the transient key for a given visitor identity.
+     *
+     * @access public
+    
+     * @param  string $did visitor identifier
+     * @return string transient key (47 chars: "51d_suspicious_" + md5)
+     */
+    public static function build_transient_key($did)
+    {
+        return '51d_suspicious_' . md5($did);
+    }
+
+    /**
+     * Returns true if the current request context should be excluded
+     * from suspicious activity tracking.
+     *
+     * @access private
+    
+     * @return bool
+     */
+    private static function is_excluded_context()
+    {
+        if (is_admin()) {
+            return true;
+        }
+
+        if (wp_doing_ajax()) {
+            return true;
+        }
+
+        if (defined('DOING_CRON') && DOING_CRON) {
+            return true;
+        }
+
+        if (defined('REST_REQUEST') && REST_REQUEST) {
+            return true;
+        }
+
+        if (defined('WP_CLI') && WP_CLI) {
+            return true;
+        }
+
+        if (defined('XMLRPC_REQUEST') && XMLRPC_REQUEST) {
+            return true;
+        }
+
+        if (php_sapi_name() === 'cli') {
+            return true;
+        }
+
+        $script = basename(isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : '');
+        if (in_array($script, ['wp-login.php', 'wp-signup.php', 'wp-activate.php'], true)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the current request is for the configured redirect
+     * target page (loop prevention).
+     *
+     * Resolves both URLs to a WordPress post ID first. This catches the
+     * case where the target page is the static front page: WordPress
+     * canonicalises /page-slug/ to / for the home request, and a plain
+     * path comparison would treat them as different and loop.
+     *
+     * @access private
+     *
+     * @return bool
+     */
+    private static function is_on_redirect_target()
+    {
+        $target = get_option(Options::SUSPICIOUS_REDIRECT_URL);
+        if (!$target) {
+            return false;
+        }
+
+        $current_uri = $_SERVER['REQUEST_URI'] ?? '/';
+
+        if (function_exists('url_to_postid') && function_exists('home_url')) {
+            $target_id = url_to_postid($target);
+            if ($target_id > 0) {
+                $current_id = url_to_postid(home_url($current_uri));
+                if ($current_id === $target_id) {
+                    return true;
+                }
+            }
+        }
+
+        $current_path = trailingslashit(strtok($current_uri, '?'));
+        $target_path = trailingslashit(
+            wp_parse_url($target, PHP_URL_PATH) ?: '/'
+        );
+
+        return $current_path === $target_path;
+    }
+}
+
+if (function_exists('add_action')) {
+    SuspiciousActivity::register();
+}

--- a/options.php
+++ b/options.php
@@ -160,5 +160,31 @@ class Options
      * Google Analytics.
      */
     const GA_AUTH_DATE = "fiftyonedegrees_ga_auth_date";
+
+    /**
+     * Options group key for suspicious activity detection settings.
+     */
+    const SUSPICIOUS_GROUP_KEY = "fiftyonedegrees_suspicious_options";
+
+    /**
+     * Key for storing whether suspicious activity detection is enabled.
+     * Value is 'on' or 'off'.
+     */
+    const SUSPICIOUS_ENABLE = "fiftyonedegrees_suspicious_enable";
+
+    /**
+     * Key for storing the URL to redirect suspicious visitors to.
+     */
+    const SUSPICIOUS_REDIRECT_URL = "fiftyonedegrees_suspicious_redirect_url";
+
+    /**
+     * Key for storing the number of requests that triggers a redirect.
+     */
+    const SUSPICIOUS_REQUESTS = "fiftyonedegrees_suspicious_requests";
+
+    /**
+     * Key for storing the time window (in seconds) for counting requests.
+     */
+    const SUSPICIOUS_WINDOW = "fiftyonedegrees_suspicious_window";
 }
 ?>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
       <file>tests/GaServiceTests.php</file>
       <file>tests/GaTrackingGtagTests.php</file>
       <file>tests/GaHookTests.php</file>
+      <file>tests/SuspiciousActivityTests.php</file>
     </testsuite>
     <testsuite name="Integration">
       <file>tests/PipelineTests.php</file>

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,10 @@ This plugin makes use of the 51Degrees Pipeline API to deliver various data inte
 
 51Degrees plugin allows you to add the Device Data Properties as Custom Dimensions to Google Analytics in a seamless and useful manner. The integration is super simple and does not require the help of a developer to set up the integration. Once you integrate Google Analytics in WordPress using 51Degrees, you will be able to fetch the Custom Dimensions in the Google Analytics Custom Reports to get the useful insights.
 
+## Suspicious Activity Detection
+
+Detect and redirect visitors who make too many requests in a short time window. Configure the threshold, time window, and redirect URL from the Suspicious tab in Settings > 51Degrees.
+
 ## Advanced Features and Developer Info
 
 For advanced feature usage, including in-page value replacement and shortcodes, conditional display based on property values, and access to 51Degrees property data from PHP and JavaScript, see the project [GitHub](https://github.com/51Degrees/pipeline-wordpress/) repository.

--- a/suspicious.php
+++ b/suspicious.php
@@ -1,0 +1,144 @@
+<?php
+/*
+    This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+    Copyright 2019 51 Degrees Mobile Experts Limited, 5 Charlotte Close,
+    Caversham, Reading, Berkshire, United Kingdom RG4 7BY.
+
+    This Original Work is licensed under the European Union Public Licence (EUPL)
+    v.1.2 and is subject to its terms as set out below.
+
+    If a copy of the EUPL was not distributed with this file, You can obtain
+    one at https://opensource.org/licenses/EUPL-1.2.
+
+    The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+    amended by the European Commission) shall be deemed incompatible for
+    the purposes of the Work and the provisions of the compatibility
+    clause in Article 5 of the EUPL shall not apply.
+*/
+
+if (!defined('ABSPATH')) { exit; }
+
+$cachedPipeline = get_option(Options::PIPELINE);
+$suspicious_enabled = get_option(Options::SUSPICIOUS_ENABLE, 'off');
+
+if ($suspicious_enabled === 'on') {
+    if (isset($cachedPipeline['error'])) {
+        echo '<p></p><span class="fod-pipeline-status warn"><b>' .
+            esc_html__('Your 51Degrees Resource Key isn\'t working. Check it on the Setup tab. Until this is fixed, tracking runs in basic mode (see below).', '51D') .
+            '</b></span>';
+    }
+
+    $engine_datakey = SuspiciousActivity::id_engine_datakey();
+    if ($engine_datakey !== null) {
+        echo '<p></p><span class="fod-pipeline-status good"><b>' .
+            esc_html__('Advanced tracking active. Visitors are identified individually even when they share a network.', '51D') .
+            '</b></span>';
+    } else {
+        echo '<p></p><span class="fod-pipeline-status warn"><b>' .
+            esc_html__('Basic tracking is active. Visitors who look identical to the site are grouped and blocked together if any one of them triggers the limit.', '51D') .
+            '</b></span>';
+    }
+}
+
+?>
+
+<form method="post" action="options.php">
+
+    <?php settings_fields(Options::SUSPICIOUS_GROUP_KEY); ?>
+
+    <table class="form-table" role="presentation">
+        <tbody>
+            <tr>
+                <th scope="row">
+                    <?php esc_html_e('Enable', '51D'); ?>
+                </th>
+                <td>
+                    <input type="hidden" name="<?php echo esc_attr(Options::SUSPICIOUS_ENABLE); ?>" value="off">
+                    <input type="checkbox"
+                           name="<?php echo esc_attr(Options::SUSPICIOUS_ENABLE); ?>"
+                           id="<?php echo esc_attr(Options::SUSPICIOUS_ENABLE); ?>"
+                           value="on"
+                           <?php checked(get_option(Options::SUSPICIOUS_ENABLE), 'on'); ?>>
+                    <label for="<?php echo esc_attr(Options::SUSPICIOUS_ENABLE); ?>">
+                        <?php esc_html_e('Enable suspicious activity detection', '51D'); ?>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="<?php echo esc_attr(Options::SUSPICIOUS_REDIRECT_URL); ?>">
+                        <?php esc_html_e('Redirect URL', '51D'); ?>
+                    </label>
+                </th>
+                <td>
+                    <input type="text"
+                           name="<?php echo esc_attr(Options::SUSPICIOUS_REDIRECT_URL); ?>"
+                           id="<?php echo esc_attr(Options::SUSPICIOUS_REDIRECT_URL); ?>"
+                           value="<?php echo esc_attr(get_option(Options::SUSPICIOUS_REDIRECT_URL)); ?>"
+                           class="regular-text">
+                    <?php
+                    $pages = get_pages();
+                    if (!empty($pages)) {
+                        echo '<p>';
+                        echo '<select id="suspicious-page-select">';
+                        echo '<option value="">' . esc_html__('-- Select a page --', '51D') . '</option>';
+                        foreach ($pages as $page) {
+                            echo '<option value="' . esc_url(get_permalink($page->ID)) . '">'
+                                . esc_html($page->post_title) . '</option>';
+                        }
+                        echo '</select>';
+                        echo '</p>';
+                    }
+                    ?>
+                    <script>
+                    (function() {
+                        var sel = document.getElementById('suspicious-page-select');
+                        if (sel) {
+                            sel.addEventListener('change', function() {
+                                if (this.value) {
+                                    document.getElementById('<?php echo esc_js(Options::SUSPICIOUS_REDIRECT_URL); ?>').value = this.value;
+                                    this.selectedIndex = 0;
+                                }
+                            });
+                        }
+                    })();
+                    </script>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="<?php echo esc_attr(Options::SUSPICIOUS_REQUESTS); ?>">
+                        <?php esc_html_e('Number of requests', '51D'); ?>
+                    </label>
+                </th>
+                <td>
+                    <input type="number"
+                           name="<?php echo esc_attr(Options::SUSPICIOUS_REQUESTS); ?>"
+                           id="<?php echo esc_attr(Options::SUSPICIOUS_REQUESTS); ?>"
+                           value="<?php echo esc_attr(get_option(Options::SUSPICIOUS_REQUESTS, 5)); ?>"
+                           min="1"
+                           class="small-text">
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="<?php echo esc_attr(Options::SUSPICIOUS_WINDOW); ?>">
+                        <?php esc_html_e('Within seconds', '51D'); ?>
+                    </label>
+                </th>
+                <td>
+                    <input type="number"
+                           name="<?php echo esc_attr(Options::SUSPICIOUS_WINDOW); ?>"
+                           id="<?php echo esc_attr(Options::SUSPICIOUS_WINDOW); ?>"
+                           value="<?php echo esc_attr(get_option(Options::SUSPICIOUS_WINDOW, 30)); ?>"
+                           min="1"
+                           max="3600"
+                           class="small-text">
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <?php submit_button(esc_html__('Save Changes', '51D')); ?>
+
+</form>

--- a/tests/PipelineTests.php
+++ b/tests/PipelineTests.php
@@ -181,6 +181,65 @@ class PipelineTests extends TestCase {
     }
 
     /**
+     * Test that when suspicious activity detection is enabled,
+     * Pipeline::process sets query.id.usage = 'non-marketing' so the
+     * cloud can generate IdProbLic / IdProbGlobal.
+     */
+    public function testProcess_SetsIdUsageWhenSuspiciousEnabled() {
+        $mock_pipeline = (new PipelineBuilder())
+            ->add(new TestFlowElement())
+            ->build();
+        $pipeline = [
+            'pipeline' => $mock_pipeline,
+            'available_engines' => ['testElement'],
+            'error' => null,
+        ];
+
+        Functions\when('get_option')->alias(function ($name, $default = null) use ($pipeline) {
+            if ($name === Options::PIPELINE) return $pipeline;
+            if ($name === Options::SUSPICIOUS_ENABLE) return 'on';
+            return $default;
+        });
+
+        Pipeline::reset();
+        Pipeline::process();
+
+        $this->assertSame(
+            'non-marketing',
+            Pipeline::$data['flowData']->evidence->get('query.id.usage')
+        );
+    }
+
+    /**
+     * Test that when suspicious activity detection is disabled,
+     * Pipeline::process does not set query.id.usage — avoids wasted
+     * 51DiD generation at the cloud for sites not using the feature.
+     */
+    public function testProcess_DoesNotSetIdUsageWhenSuspiciousDisabled() {
+        $mock_pipeline = (new PipelineBuilder())
+            ->add(new TestFlowElement())
+            ->build();
+        $pipeline = [
+            'pipeline' => $mock_pipeline,
+            'available_engines' => ['testElement'],
+            'error' => null,
+        ];
+
+        Functions\when('get_option')->alias(function ($name, $default = null) use ($pipeline) {
+            if ($name === Options::PIPELINE) return $pipeline;
+            if ($name === Options::SUSPICIOUS_ENABLE) return 'off';
+            return $default;
+        });
+
+        Pipeline::reset();
+        Pipeline::process();
+
+        $this->assertNull(
+            Pipeline::$data['flowData']->evidence->get('query.id.usage')
+        );
+    }
+
+    /**
      * Test that the process method returns the expected result.
      */
     public function testProcess() {

--- a/tests/SuspiciousActivityTests.php
+++ b/tests/SuspiciousActivityTests.php
@@ -1,0 +1,767 @@
+<?php
+/*
+    This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+    Copyright 2019 51 Degrees Mobile Experts Limited, 5 Charlotte Close,
+    Caversham, Reading, Berkshire, United Kingdom RG4 7BY.
+
+    This Original Work is licensed under the European Union Public Licence (EUPL)
+    v.1.2 and is subject to its terms as set out below.
+
+    If a copy of the EUPL was not distributed with this file, You can obtain
+    one at https://opensource.org/licenses/EUPL-1.2.
+
+    The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+    amended by the European Commission) shall be deemed incompatible for
+    the purposes of the Work and the provisions of the compatibility
+    clause in Article 5 of the EUPL shall not apply.
+*/
+
+require_once(__DIR__ . '/../includes/suspicious-activity.php');
+require_once(__DIR__ . '/../includes/pipeline.php');
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Brain\Monkey\Functions;
+use Brain\Monkey;
+
+class ExitException extends \Exception {}
+
+class SuspiciousActivityTests extends TestCase
+{
+    private $options = [];
+    private $transients = [];
+
+    public function set_up()
+    {
+        Pipeline::reset();
+        parent::set_up();
+        Monkey\setUp();
+
+        $this->options = [
+            Options::SUSPICIOUS_ENABLE => 'off',
+            Options::SUSPICIOUS_REDIRECT_URL => 'http://example.com/blocked/',
+            Options::SUSPICIOUS_REQUESTS => 5,
+            Options::SUSPICIOUS_WINDOW => 30,
+        ];
+        $this->transients = [];
+
+        $opts = &$this->options;
+        $trans = &$this->transients;
+
+        Functions\when('get_option')->alias(function ($key, $default = '') use (&$opts) {
+            return array_key_exists($key, $opts) ? $opts[$key] : $default;
+        });
+
+        Functions\when('get_transient')->alias(function ($key) use (&$trans) {
+            return isset($trans[$key]) ? $trans[$key] : false;
+        });
+
+        Functions\when('set_transient')->alias(function ($key, $value, $ttl = 0) use (&$trans) {
+            $trans[$key] = $value;
+            return true;
+        });
+
+        Functions\when('is_admin')->justReturn(false);
+        Functions\when('wp_doing_ajax')->justReturn(false);
+        Functions\when('trailingslashit')->alias(function ($string) {
+            return rtrim($string, '/\\') . '/';
+        });
+        Functions\when('wp_parse_url')->alias(function ($url, $component = -1) {
+            return parse_url($url, $component);
+        });
+        Functions\when('home_url')->alias(function ($path = '/') {
+            return 'http://example.com' . $path;
+        });
+        Functions\when('url_to_postid')->justReturn(0);
+        Functions\when('sanitize_text_field')->returnArg();
+        Functions\when('wp_unslash')->returnArg();
+        Functions\when('error_log')->justReturn(true);
+
+        \Patchwork\redefine('headers_sent', function () {
+            return false;
+        });
+        \Patchwork\redefine('php_sapi_name', function () {
+            return 'apache2handler';
+        });
+
+        $_SERVER['REMOTE_ADDR'] = '192.168.1.100';
+        $_SERVER['HTTP_USER_AGENT'] = 'TestBrowser/1.0';
+        $_SERVER['REQUEST_URI'] = '/some-page/';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+    }
+
+    public function tear_down()
+    {
+        \Patchwork\restoreAll();
+        Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    private function buildMockFlowData($engine, $propName, $value)
+    {
+        $propObj = new \stdClass();
+        $propObj->hasValue = ($value !== null);
+        $propObj->value = $value;
+        if ($value === null) {
+            $propObj->noValueMessage = 'No value';
+        }
+
+        $engineObj = new \stdClass();
+        $engineObj->{$propName} = $propObj;
+
+        $flowData = new \stdClass();
+        $flowData->{$engine} = $engineObj;
+
+        return $flowData;
+    }
+
+    /**
+     * Assembles a 117-byte OWID v3 envelope matching the spec at
+     * .claude/issues/pipeline-wordpress/16/2026-04-24-51did-core-engine-spec.md
+     * and returns it base64-encoded.
+     */
+    private function buildOwid($identity32, $signature64 = null, $version = 3)
+    {
+        if (strlen($identity32) !== 32) {
+            throw new \InvalidArgumentException('identity must be exactly 32 bytes');
+        }
+        $signature = $signature64 ?? str_repeat("\x00", 64);
+        if (strlen($signature) !== 64) {
+            throw new \InvalidArgumentException('signature must be exactly 64 bytes');
+        }
+        $envelope = chr($version)            // Version (1 byte)
+            . "51d.es\x00"                   // Domain (7 bytes, null-terminated)
+            . pack('V', 3320214)              // Date (4 bytes LE, arbitrary minutes)
+            . pack('V', 37)                   // Payload Length (4 bytes LE)
+            . "\x01"                         // Usage Signal (1 byte, non-marketing)
+            . pack('V', 19493)                // License Key ID (4 bytes LE, arbitrary)
+            . $identity32                     // Identifier (32 bytes)
+            . $signature;                     // Signature (64 bytes)
+        return base64_encode($envelope);
+    }
+
+    /**
+     * Test that no transient reads or redirects happen when the feature
+     * is disabled.
+     */
+    public function testFeatureDisabledDoesNothing()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'off';
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on admin requests.
+     */
+    public function testSkippedOnAdmin()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        Functions\when('is_admin')->justReturn(true);
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on AJAX requests.
+     */
+    public function testSkippedOnAjax()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        Functions\when('wp_doing_ajax')->justReturn(true);
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on CLI requests.
+     */
+    public function testSkippedOnCli()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        \Patchwork\redefine('php_sapi_name', function () {
+            return 'cli';
+        });
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on wp-login.php.
+     */
+    public function testSkippedOnWpLogin()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $_SERVER['SCRIPT_NAME'] = '/wp-login.php';
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on wp-signup.php.
+     */
+    public function testSkippedOnWpSignup()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $_SERVER['SCRIPT_NAME'] = '/wp-signup.php';
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on wp-activate.php.
+     */
+    public function testSkippedOnWpActivate()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $_SERVER['SCRIPT_NAME'] = '/wp-activate.php';
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped when headers have already been sent.
+     */
+    public function testSkippedWhenHeadersSent()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        \Patchwork\redefine('headers_sent', function () {
+            return true;
+        });
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that a zero window value causes an early return.
+     */
+    public function testZeroWindowReturnsEarly()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_WINDOW] = 0;
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that a zero threshold value causes an early return.
+     */
+    public function testZeroThresholdReturnsEarly()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 0;
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that get_51did extracts the 32-byte Identifier from a valid
+     * IdProbLic OWID token and returns it as a 64-char hex string.
+     */
+    public function testIdentityIdProbLicAvailable()
+    {
+        $identity = str_repeat("\x7f", 32);
+        $token = $this->buildOwid($identity);
+
+        Pipeline::$data = [
+            'properties' => [
+                'did_engine' => [
+                    'idproblic' => ['name' => 'IdProbLic', 'type' => 'String'],
+                ],
+            ],
+            'flowData' => $this->buildMockFlowData('did_engine', 'idproblic', $token),
+            'errors' => [],
+        ];
+
+        $result = SuspiciousActivity::get_51did();
+        self::assertEquals(bin2hex($identity), $result);
+    }
+
+    /**
+     * Test that get_51did falls back to IdProbGlobal when IdProbLic is
+     * absent, and extracts the Identifier from it the same way.
+     */
+    public function testIdentityIdProbGlobalFallback()
+    {
+        $identity = str_repeat("\xA3", 32);
+        $token = $this->buildOwid($identity);
+
+        Pipeline::$data = [
+            'properties' => [
+                'did_engine' => [
+                    'idprobglobal' => ['name' => 'IdProbGlobal', 'type' => 'String'],
+                ],
+            ],
+            'flowData' => $this->buildMockFlowData('did_engine', 'idprobglobal', $token),
+            'errors' => [],
+        ];
+
+        $result = SuspiciousActivity::get_51did();
+        self::assertEquals(bin2hex($identity), $result);
+    }
+
+    /**
+     * Test that the same Identifier yields the same tracking key even
+     * when the OWID signature suffix rotates per request, which it does
+     * under random-k ECDSA on the cloud side.
+     */
+    public function testIdentityStableAcrossVaryingSignatures()
+    {
+        $identity = str_repeat("\x55", 32);
+        $tokenA = $this->buildOwid($identity, str_repeat("\x01", 64));
+        $tokenB = $this->buildOwid($identity, str_repeat("\xFE", 64));
+        self::assertNotEquals($tokenA, $tokenB);
+
+        Pipeline::$data = [
+            'properties' => [
+                'did_engine' => ['idproblic' => ['name' => 'IdProbLic', 'type' => 'String']],
+            ],
+            'flowData' => $this->buildMockFlowData('did_engine', 'idproblic', $tokenA),
+            'errors' => [],
+        ];
+        $resultA = SuspiciousActivity::get_51did();
+
+        Pipeline::$data['flowData'] = $this->buildMockFlowData('did_engine', 'idproblic', $tokenB);
+        $resultB = SuspiciousActivity::get_51did();
+
+        self::assertEquals($resultA, $resultB);
+        self::assertEquals(bin2hex($identity), $resultA);
+    }
+
+    /**
+     * Test that an unparseable OWID value falls through to the IP+UA
+     * hash so the feature still tracks visitors under cloud-side errors
+     * or unexpected data.
+     */
+    public function testIdentityMalformedOwidFallsBackToIpUa()
+    {
+        Pipeline::$data = [
+            'properties' => [
+                'did_engine' => ['idproblic' => ['name' => 'IdProbLic', 'type' => 'String']],
+            ],
+            'flowData' => $this->buildMockFlowData('did_engine', 'idproblic', 'not-a-valid-owid-string'),
+            'errors' => [],
+        ];
+
+        $result = SuspiciousActivity::get_51did();
+        $expected = hash('sha256', '192.168.1.100|TestBrowser/1.0');
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that an OWID with a version byte other than 3 is rejected,
+     * preventing silent misinterpretation if the cloud later issues v4
+     * tokens with a different byte layout.
+     */
+    public function testIdentityWrongVersionFallsBackToIpUa()
+    {
+        $identity = str_repeat("\x01", 32);
+        $token = $this->buildOwid($identity, null, 4);
+
+        Pipeline::$data = [
+            'properties' => [
+                'did_engine' => ['idproblic' => ['name' => 'IdProbLic', 'type' => 'String']],
+            ],
+            'flowData' => $this->buildMockFlowData('did_engine', 'idproblic', $token),
+            'errors' => [],
+        ];
+
+        $result = SuspiciousActivity::get_51did();
+        $expected = hash('sha256', '192.168.1.100|TestBrowser/1.0');
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that get_51did falls back to an IP+UA hash when no pipeline
+     * identity properties are available.
+     */
+    public function testIdentityFallbackToIpUaHash()
+    {
+        Pipeline::$data = [
+            'properties' => [],
+            'flowData' => null,
+            'errors' => [],
+        ];
+
+        $result = SuspiciousActivity::get_51did();
+        $expected = hash('sha256', '192.168.1.100|TestBrowser/1.0');
+        self::assertEquals($expected, $result);
+        self::assertEquals(64, strlen($result));
+    }
+
+    /**
+     * Test that the IP+UA hash is stable across multiple calls with the
+     * same server variables.
+     */
+    public function testIdentityIpUaHashIsStable()
+    {
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $result1 = SuspiciousActivity::get_51did();
+        $result2 = SuspiciousActivity::get_51did();
+        self::assertEquals($result1, $result2);
+    }
+
+    /**
+     * Test that no redirect fires when the request count is under the
+     * configured threshold.
+     */
+    public function testUnderThresholdNoRedirect()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 5;
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $did = SuspiciousActivity::get_51did();
+        $key = SuspiciousActivity::build_transient_key($did);
+        $now = microtime(true);
+        $this->transients[$key] = [$now - 5, $now - 3, $now - 1];
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertCount(4, $this->transients[$key]);
+    }
+
+    /**
+     * Test that the redirect fires when the request count equals the
+     * configured threshold (>= semantics).
+     */
+    public function testAtThresholdRedirectFires()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 5;
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $did = SuspiciousActivity::get_51did();
+        $key = SuspiciousActivity::build_transient_key($did);
+        $now = microtime(true);
+        $this->transients[$key] = [$now - 4, $now - 3, $now - 2, $now - 1];
+
+        Functions\expect('wp_safe_redirect')
+            ->once()
+            ->with('http://example.com/blocked/', 302)
+            ->andReturnUsing(function () {
+                throw new ExitException('redirect');
+            });
+
+        try {
+            SuspiciousActivity::check_and_maybe_redirect();
+            self::fail('Expected ExitException from wp_safe_redirect');
+        } catch (ExitException $e) {
+            self::assertEquals('redirect', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test that the redirect fires when the request count exceeds the
+     * configured threshold.
+     */
+    public function testOverThresholdRedirectFires()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 5;
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $did = SuspiciousActivity::get_51did();
+        $key = SuspiciousActivity::build_transient_key($did);
+        $now = microtime(true);
+        $this->transients[$key] = [$now - 5, $now - 4, $now - 3, $now - 2, $now - 1];
+
+        Functions\expect('wp_safe_redirect')
+            ->once()
+            ->with('http://example.com/blocked/', 302)
+            ->andReturnUsing(function () {
+                throw new ExitException('redirect');
+            });
+
+        try {
+            SuspiciousActivity::check_and_maybe_redirect();
+            self::fail('Expected ExitException from wp_safe_redirect');
+        } catch (ExitException $e) {
+            self::assertEquals('redirect', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test that the first request from a visitor creates a single-entry
+     * transient and does not redirect.
+     */
+    public function testFirstRequestNoRedirect()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 5;
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        $did = SuspiciousActivity::get_51did();
+        $key = SuspiciousActivity::build_transient_key($did);
+        self::assertArrayHasKey($key, $this->transients);
+        self::assertCount(1, $this->transients[$key]);
+    }
+
+    /**
+     * Test that no redirect fires when the threshold is exceeded but
+     * no redirect URL is configured.
+     */
+    public function testOverThresholdNoRedirectUrlNoRedirect()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 2;
+        $this->options[Options::SUSPICIOUS_REDIRECT_URL] = '';
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $did = SuspiciousActivity::get_51did();
+        $key = SuspiciousActivity::build_transient_key($did);
+        $now = microtime(true);
+        $this->transients[$key] = [$now - 1, $now - 0.5];
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertTrue(true);
+    }
+
+    /**
+     * Test that no redirect fires when the current request path matches
+     * the redirect target path (loop prevention).
+     */
+    public function testLoopPreventionMatchingPaths()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 1;
+        $this->options[Options::SUSPICIOUS_REDIRECT_URL] = 'http://example.com/blocked/';
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $_SERVER['REQUEST_URI'] = '/blocked/';
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that loop prevention also catches the static-front-page case:
+     * when the redirect target is the page set as the home page,
+     * WordPress canonicalises /page-slug/ to /, and a path-only
+     * comparison would treat them as different and loop. Both URLs
+     * resolve to the same post ID via url_to_postid.
+     */
+    public function testLoopPreventionStaticFrontPage()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 1;
+        $this->options[Options::SUSPICIOUS_REDIRECT_URL] = 'http://example.com/blocked/';
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        Functions\when('url_to_postid')->alias(function ($url) {
+            return 4;
+        });
+
+        $_SERVER['REQUEST_URI'] = '/';
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that two URLs resolving to different post IDs are treated as
+     * different pages and the threshold check still fires.
+     */
+    public function testLoopPreventionDifferentPostIdsDoNotMatch()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 1;
+        $this->options[Options::SUSPICIOUS_REDIRECT_URL] = 'http://example.com/blocked/';
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        Functions\when('url_to_postid')->alias(function ($url) {
+            return strpos($url, '/blocked/') !== false ? 4 : 7;
+        });
+
+        $_SERVER['REQUEST_URI'] = '/some-other-page/';
+
+        Functions\expect('wp_safe_redirect')
+            ->once()
+            ->andReturnUsing(function () {
+                throw new ExitException('redirect');
+            });
+
+        try {
+            SuspiciousActivity::check_and_maybe_redirect();
+            self::fail('Expected ExitException from wp_safe_redirect');
+        } catch (ExitException $e) {
+            self::assertEquals('redirect', $e->getMessage());
+        }
+    }
+
+    /**
+     * Test that the IP+UA hash works with non-ASCII and binary characters
+     * in the User-Agent string.
+     */
+    public function testNonAsciiUaHashWorks()
+    {
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+        $_SERVER['HTTP_USER_AGENT'] = "\xff\xfe\x00\x01 " . chr(0) . " binary";
+
+        $result = SuspiciousActivity::get_51did();
+        self::assertEquals(64, strlen($result));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $result);
+    }
+
+    /**
+     * Test that the enable sanitizer only accepts 'on' as a truthy value.
+     */
+    public function testSanitizeEnableCheckbox()
+    {
+        $sanitize = function ($v) { return $v === 'on' ? 'on' : 'off'; };
+
+        self::assertEquals('on', $sanitize('on'));
+        self::assertEquals('off', $sanitize('off'));
+        self::assertEquals('off', $sanitize(''));
+        self::assertEquals('off', $sanitize(null));
+        self::assertEquals('off', $sanitize('yes'));
+    }
+
+    /**
+     * Test that truthy-looking values like 'off', '0', and false all
+     * sanitize to 'off'.
+     */
+    public function testSanitizeTruthyOffTrap()
+    {
+        $sanitize = function ($v) { return $v === 'on' ? 'on' : 'off'; };
+
+        self::assertEquals('off', $sanitize('off'));
+        self::assertEquals('off', $sanitize(''));
+        self::assertEquals('off', $sanitize('0'));
+        self::assertEquals('off', $sanitize(false));
+        self::assertEquals('on', $sanitize('on'));
+    }
+
+    /**
+     * Test that the requests and window sanitizers clamp values to their
+     * valid ranges.
+     */
+    public function testSanitizeBounds()
+    {
+        $sanitize_requests = function ($v) { return max(1, (int) $v); };
+        $sanitize_window = function ($v) { return max(1, min(3600, (int) $v)); };
+
+        self::assertEquals(1, $sanitize_requests(0));
+        self::assertEquals(1, $sanitize_requests(-5));
+        self::assertEquals(10, $sanitize_requests(10));
+
+        self::assertEquals(1, $sanitize_window(0));
+        self::assertEquals(1, $sanitize_window(-5));
+        self::assertEquals(3600, $sanitize_window(9999));
+        self::assertEquals(60, $sanitize_window(60));
+    }
+
+    /**
+     * Test that timestamps older than the configured window are pruned
+     * before the count is evaluated.
+     */
+    public function testExpiredTimestampsPruned()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        $this->options[Options::SUSPICIOUS_REQUESTS] = 10;
+        $this->options[Options::SUSPICIOUS_WINDOW] = 30;
+        Pipeline::$data = ['properties' => [], 'flowData' => null, 'errors' => []];
+
+        $did = SuspiciousActivity::get_51did();
+        $key = SuspiciousActivity::build_transient_key($did);
+        $now = microtime(true);
+        $this->transients[$key] = [
+            $now - 100,
+            $now - 60,
+            $now - 50,
+            $now - 2,
+            $now - 1,
+        ];
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertCount(3, $this->transients[$key]);
+    }
+
+    /**
+     * Test that the transient key is built from an md5 hash of the
+     * visitor identity.
+     */
+    public function testTransientKeyFormat()
+    {
+        $key = SuspiciousActivity::build_transient_key('abc');
+        self::assertEquals('51d_suspicious_' . md5('abc'), $key);
+        self::assertEquals(47, strlen($key));
+    }
+
+    /**
+     * Constant-based exclusion tests MUST be last. PHP constants persist
+     * across tests in the same process, so once defined they contaminate
+     * all subsequent tests.
+     */
+
+    /**
+     * Test that the redirect is skipped during cron execution.
+     */
+    public function testSkippedOnCron()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        if (!defined('DOING_CRON')) {
+            define('DOING_CRON', true);
+        }
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on REST API requests.
+     */
+    public function testSkippedOnRest()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        if (!defined('REST_REQUEST')) {
+            define('REST_REQUEST', true);
+        }
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+
+    /**
+     * Test that the redirect is skipped on XML-RPC requests.
+     */
+    public function testSkippedOnXmlRpc()
+    {
+        $this->options[Options::SUSPICIOUS_ENABLE] = 'on';
+        if (!defined('XMLRPC_REQUEST')) {
+            define('XMLRPC_REQUEST', true);
+        }
+
+        SuspiciousActivity::check_and_maybe_redirect();
+
+        self::assertEmpty($this->transients);
+    }
+}

--- a/tests/patchwork.json
+++ b/tests/patchwork.json
@@ -1,5 +1,8 @@
 {
     "redefinable-internals": [
-        "session_status"
+        "session_status",
+        "headers_sent",
+        "php_sapi_name",
+        "error_log"
     ]
 }


### PR DESCRIPTION
Tracks per-visitor request rates using WordPress transients and redirects visitors who exceed a configured threshold. Uses IdProbLic/IdProbGlobal from the 51Degrees pipeline for visitor identity with IP+UA hash fallback.