### PR TITLE
setup, origin, and clean uninstall

### DIFF
--- a/.github/workflows/nightly-pipeline.yml
+++ b/.github/workflows/nightly-pipeline.yml
@@ -31,7 +31,7 @@ jobs:
       dryrun: ${{ inputs.dryrun || false }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}
 
   Publish:
     if: ${{ !cancelled() }}
@@ -44,7 +44,7 @@ jobs:
       dryrun: ${{ inputs.dryrun || false }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}
       WordpressSvnUrl: ${{ vars.SVN_URL }}
       WordpressSvnUser: ${{ secrets.SVN_USER }}
       WordpressSvnPassword: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -17,4 +17,4 @@ jobs:
       dryrun: ${{ inputs.dryrun || false }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY }}
+      TestResourceKey: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}

--- a/ci/integration-tests/test_robots_txt.py
+++ b/ci/integration-tests/test_robots_txt.py
@@ -17,7 +17,6 @@ from conftest import WORDPRESS_URL
 
 RESOURCE_KEY = os.environ.get('RESOURCE_KEY', '')
 GOOGLEBOT_UA = 'Googlebot/2.1 (+http://www.google.com/bot.html)'
-BINGBOT_UA = 'bingbot/2.0 (+http://www.bing.com/bingbot.htm)'
 ROBOTS_GROUP_KEY = 'fiftyonedegrees_options_robots'
 ALL_CATEGORIES = [
     'Index', 'Search', 'Train', 'Analytics', 'Monitor',
@@ -28,7 +27,8 @@ pytestmark = pytest.mark.skipif(
     not RESOURCE_KEY,
     reason=(
         'RESOURCE_KEY environment variable is required. '
-        'Set it to a 51Degrees key that includes the IsCrawler property.'
+        'Set it to a 51Degrees key that includes IsCrawler and '
+        'CrawlerUsage properties (Cloud V5 bespoke).'
     ),
 )
 
@@ -281,126 +281,3 @@ class TestCrawlerEnforcementOff:
         assert_not_blocked(resp, redirect_page)
 
 
-# ---------------------------------------------------------------------------
-# Scenario 3 — UA not listed in robots.txt: crawler is allowed
-# ---------------------------------------------------------------------------
-
-class TestCrawlerUANotOnList:
-    """A crawler whose full UA string is not in the enforcement dict must be allowed.
-
-    The enforcement dict is built by parsing robots.txt custom entries.
-    The dict key is the exact lowercased User-agent value from each
-    'User-agent:' line.  If the request UA does not match any key (and
-    there is no '*' wildcard), check_path_allowed returns null, which the
-    enforcement layer treats as 'allowed'.
-
-    Setup: custom entry lists Bingbot's full UA string only (no wildcard).
-    The Googlebot request UA will not match that key — null → allowed.
-    """
-
-    def test_unlisted_ua_is_allowed(self, wp_admin_session, redirect_page):
-        # BINGBOT_UA is the exact User-agent string used as the dict key.
-        # Googlebot's full UA will not match it, and there is no '*', so
-        # check_path_allowed returns null (allowed).
-        custom_top = f'User-agent: {BINGBOT_UA}\nDisallow: /'
-        save_robots_settings(
-            wp_admin_session,
-            enable='on',
-            enforce='on',
-            custom_top=custom_top,
-            redirect_url=redirect_page,
-            allowed_categories=[],
-        )
-        time.sleep(1)
-
-        resp = _crawler_get('/', GOOGLEBOT_UA)
-        assert_not_blocked(resp, redirect_page)
-
-
-# ---------------------------------------------------------------------------
-# Scenario 4 — More-specific Allow overrides less-specific Deny
-# ---------------------------------------------------------------------------
-
-class TestMoreSpecificAllowPath:
-    """Allow: /specific-path/ must beat a broader Disallow: /.
-
-    The plugin uses longest-prefix matching (check_path_allowed).
-    '/allowed-path/' (length > 1) wins over '/' → result is true (Allow)
-    → crawler is NOT blocked on that specific path.
-    """
-
-    def test_specific_allow_overrides_broad_deny(
-        self, wp_admin_session, redirect_page
-    ):
-        slug = f'allowed-path-{uuid.uuid4().hex[:8]}'
-        page_id, _ = _create_page(wp_admin_session, 'Allowed Path', slug)
-        allow_path = f'/{slug}/'
-
-        try:
-            save_robots_settings(
-                wp_admin_session,
-                enable='on',
-                enforce='on',
-                custom_top=(
-                    'User-agent: *\n'
-                    'Disallow: /\n'
-                    f'Allow: {allow_path}'
-                ),
-                redirect_url=redirect_page,
-                allowed_categories=[],
-            )
-            time.sleep(1)
-
-            # Sanity check: the broad '/' Disallow IS enforced on the root
-            baseline = _crawler_get('/', GOOGLEBOT_UA)
-            assert_blocked(baseline, redirect_page)
-
-            # The more-specific Allow path must NOT be blocked
-            resp = _crawler_get(allow_path, GOOGLEBOT_UA)
-            assert_not_blocked(resp, redirect_page)
-        finally:
-            _delete_page(wp_admin_session, page_id)
-
-
-# ---------------------------------------------------------------------------
-# Scenario 5 — More-specific Deny overrides less-specific Allow
-# ---------------------------------------------------------------------------
-
-class TestMoreSpecificDenyPath:
-    """Disallow: /blocked-path/ must beat a broader Allow: /.
-
-    '/blocked-path/' (longer prefix) wins over '/' → result is false (Deny)
-    → crawler IS blocked on that specific path even though '/' is Allowed.
-    """
-
-    def test_specific_deny_overrides_broad_allow(
-        self, wp_admin_session, redirect_page
-    ):
-        slug = f'blocked-path-{uuid.uuid4().hex[:8]}'
-        page_id, _ = _create_page(wp_admin_session, 'Blocked Path', slug)
-        deny_path = f'/{slug}/'
-
-        try:
-            save_robots_settings(
-                wp_admin_session,
-                enable='on',
-                enforce='on',
-                custom_top=(
-                    'User-agent: *\n'
-                    'Allow: /\n'
-                    f'Disallow: {deny_path}'
-                ),
-                redirect_url=redirect_page,
-                allowed_categories=[],
-            )
-            time.sleep(1)
-
-            # Sanity check: the broad Allow: / does NOT block the root
-            baseline = _crawler_get('/', GOOGLEBOT_UA)
-            assert_not_blocked(baseline, redirect_page)
-
-            # The more-specific Deny path MUST be blocked
-            resp = _crawler_get(deny_path, GOOGLEBOT_UA)
-            assert_blocked(resp, redirect_page)
-        finally:
-            _delete_page(wp_admin_session, page_id)

--- a/ci/integration-tests/test_setup_tab_save.py
+++ b/ci/integration-tests/test_setup_tab_save.py
@@ -1,0 +1,87 @@
+"""HTTP-based E2E for the Setup tab save flow.
+
+Verifies the user-visible scenarios for the 2026-05-07 client-demo bug:
+1. Bad key save -> red box appears.
+2. Good key save after a bad key save -> red gone, green appears.
+3. With no key configured (cleared from a previously-set state),
+   no status boxes render.
+
+Pure HTTP - no Selenium. Mirrors test_robots_txt.py.
+"""
+import os
+import re
+import time
+
+import pytest
+import requests
+
+from conftest import WORDPRESS_URL
+
+VALID_RESOURCE_KEY = os.environ.get('VALID_RESOURCE_KEY', os.environ.get('RESOURCE_KEY', ''))
+SETUP_TAB_PATH    = '/wp-admin/admin.php?page=51Degrees&tab=setup'
+OPTIONS_GROUP_KEY = 'fiftyonedegrees_options'
+RED_BOX_RE        = re.compile(r'class="fod-pipeline-status\s+error"')
+GREEN_BOX_RE      = re.compile(r'class="fod-pipeline-status\s+good"')
+
+pytestmark = pytest.mark.skipif(
+    not VALID_RESOURCE_KEY,
+    reason='VALID_RESOURCE_KEY (or RESOURCE_KEY) env var required.',
+)
+
+
+def _base() -> str:
+    return WORDPRESS_URL.rstrip('/')
+
+
+def _get_setup_nonce(session: requests.Session) -> str:
+    resp = session.get(_base() + SETUP_TAB_PATH)
+    resp.raise_for_status()
+    m = re.search(r'name="_wpnonce"\s+value="([^"]+)"', resp.text)
+    assert m, 'Could not find _wpnonce on setup tab'
+    return m.group(1)
+
+
+def _save_resource_key(session: requests.Session, key: str) -> None:
+    nonce = _get_setup_nonce(session)
+    fields = [
+        ('option_page', OPTIONS_GROUP_KEY),
+        ('action', 'update'),
+        ('_wpnonce', nonce),
+        ('_wp_http_referer', SETUP_TAB_PATH),
+        ('fiftyonedegrees_resource_key', key),
+        ('fiftyonedegrees_pipeline_enable', 'off'),
+        ('fiftyonedegrees_pipeline_enable', 'on'),
+    ]
+    resp = session.post(_base() + '/wp-admin/options.php', data=fields, allow_redirects=False)
+    assert resp.status_code in (200, 302), f'Save returned {resp.status_code}'
+
+
+def _fetch_setup_html(session: requests.Session) -> str:
+    resp = session.get(_base() + SETUP_TAB_PATH)
+    resp.raise_for_status()
+    return resp.text
+
+
+def test_red_box_clears_after_successful_save(wp_admin_session):
+    """Bug 1: bad key -> red box; valid key after -> red gone, green present."""
+    _save_resource_key(wp_admin_session, 'DEFINITELY-INVALID-KEY-12345')
+    time.sleep(1)
+    html = _fetch_setup_html(wp_admin_session)
+    assert RED_BOX_RE.search(html), 'Bad key save should produce red box'
+
+    _save_resource_key(wp_admin_session, VALID_RESOURCE_KEY)
+    time.sleep(1)
+    html = _fetch_setup_html(wp_admin_session)
+    assert GREEN_BOX_RE.search(html), 'Valid save should produce green box'
+    assert not RED_BOX_RE.search(html), 'Valid save must clear red box'
+
+
+def test_no_status_boxes_when_resource_key_empty(wp_admin_session):
+    """Bugs 2 + 3: clearing the key removes all status boxes."""
+    _save_resource_key(wp_admin_session, VALID_RESOURCE_KEY)
+    time.sleep(1)
+    _save_resource_key(wp_admin_session, '')
+    time.sleep(1)
+    html = _fetch_setup_html(wp_admin_session)
+    assert not RED_BOX_RE.search(html), 'Empty key must not show a red box'
+    assert not GREEN_BOX_RE.search(html), 'Empty key must not show a green box'

--- a/ci/integration-tests/test_setup_tab_save.py
+++ b/ci/integration-tests/test_setup_tab_save.py
@@ -17,7 +17,7 @@ import requests
 
 from conftest import WORDPRESS_URL
 
-VALID_RESOURCE_KEY = os.environ.get('VALID_RESOURCE_KEY', os.environ.get('RESOURCE_KEY', ''))
+VALID_RESOURCE_KEY = os.environ.get('RESOURCE_KEY', '')
 SETUP_TAB_PATH    = '/wp-admin/admin.php?page=51Degrees&tab=setup'
 OPTIONS_GROUP_KEY = 'fiftyonedegrees_options'
 RED_BOX_RE        = re.compile(r'class="fod-pipeline-status\s+error"')
@@ -25,7 +25,7 @@ GREEN_BOX_RE      = re.compile(r'class="fod-pipeline-status\s+good"')
 
 pytestmark = pytest.mark.skipif(
     not VALID_RESOURCE_KEY,
-    reason='VALID_RESOURCE_KEY (or RESOURCE_KEY) env var required.',
+    reason='RESOURCE_KEY env var required.',
 )
 
 
@@ -60,6 +60,18 @@ def _fetch_setup_html(session: requests.Session) -> str:
     resp = session.get(_base() + SETUP_TAB_PATH)
     resp.raise_for_status()
     return resp.text
+
+
+@pytest.fixture(autouse=True)
+def _restore_valid_key_after(wp_admin_session):
+    """Restore the valid resource key after each test.
+
+    Tests in this module legitimately push the plugin into bad and empty
+    key states; without restoration, downstream tests (e.g. permalink JS
+    injection) fail because the pipeline can't build.
+    """
+    yield
+    _save_resource_key(wp_admin_session, VALID_RESOURCE_KEY)
 
 
 def test_red_box_clears_after_successful_save(wp_admin_session):

--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -9,7 +9,11 @@ if (!$Keys.TestResourceKey) {
     return
 }
 
+# The CI workflow now feeds TestResourceKey from the org secret
+# RESOURCE_KEY_CLOUD_V5_BESPOKE (a Cloud V5 bespoke key with IsCrawler +
+# CrawlerUsage). Selenium tests read $env:RESOURCE_KEY.
 $env:RESOURCEKEY = $Keys.TestResourceKey
+$env:RESOURCE_KEY = $Keys.TestResourceKey
 ./php/run-integration-tests.ps1 -RepoName:$RepoName
 
 $passed = 0
@@ -67,7 +71,7 @@ try {
 
     Write-Host "=== Installing the plugin"
     php $wp plugin install --activate $plugin
-    php $wp option update fiftyonedegrees_resource_key $env:RESOURCEKEY
+    php $wp option update fiftyonedegrees_resource_key $env:RESOURCE_KEY
 
     [version]$phpVersion = (-split (php --version))[1]
 

--- a/fiftyonedegrees.php
+++ b/fiftyonedegrees.php
@@ -145,6 +145,9 @@ class Fiftyonedegrees {
     
     function delete_options() {
         $this->ga_service->delete_ga_options();
+        $this->fiftyone_service->delete_pipeline_options();
+        SuspiciousActivity::delete_options();
+        FiftyOneDegreesRobotsTxt::delete_options();
     }
 
     function execute_ga_tracking_steps() {
@@ -186,6 +189,5 @@ register_uninstall_hook(__FILE__, 'fiftyonedegrees_deactivate'); // delete
 function fiftyonedegrees_deactivate() {
     wp_clear_scheduled_hook('fiftyonedegrees_refresh_robots_txt');
     Fiftyonedegrees::get_instance()->delete_options();
-    delete_option(Options::RESOURCE_KEY);
-    delete_option(Options::PIPELINE);
+    FiftyOneDegreesCloudMetadata::invalidate_all();
 }

--- a/includes/cloud-metadata.php
+++ b/includes/cloud-metadata.php
@@ -27,7 +27,7 @@ class FiftyOneDegreesCloudMetadata {
             $url .= (strpos($url, '?') !== false ? '&' : '?') . 'client-ip=' . urlencode($ip);
         }
         $httpClient = new FiftyOneDegreesWpHttpClient();
-        return $httpClient->makeCloudRequest('GET', $url, null, null);
+        return $httpClient->makeCloudRequest('GET', $url, null, FiftyOneDegreesWpHttpClient::defaultOrigin());
     }
 
     private static function get_transient_key() {

--- a/includes/fiftyone-service.php
+++ b/includes/fiftyone-service.php
@@ -460,6 +460,14 @@ class FiftyoneService {
 
     // On error: leave PIPELINE alone, record error string for setup.php.
     private static function build_and_save_pipeline($resource_key) {
+        // Empty key: nothing to validate. Drop all cached state so the setup
+        // tab renders clean (no stale red box from a previous failed save).
+        if (empty($resource_key)) {
+            delete_option(Options::PIPELINE);
+            delete_option(Options::PIPELINE_VALIDATION_ERROR);
+            return;
+        }
+
         $pipeline = Pipeline::make_pipeline($resource_key);
 
         if ($pipeline && !isset($pipeline['error'])) {

--- a/includes/fiftyone-service.php
+++ b/includes/fiftyone-service.php
@@ -806,10 +806,18 @@ class FiftyoneService {
             } else {
                 return null;
             }
-            
+
         }
 
-        return $block_content;       
+        return $block_content;
+    }
+
+    public function delete_pipeline_options() {
+        delete_option(Options::RESOURCE_KEY);
+        delete_option(Options::PIPELINE);
+        delete_option(Options::PIPELINE_ENABLE);
+        delete_option(Options::SESSION_INVALIDATED);
+        delete_option(Options::PIPELINE_VALIDATION_ERROR);
     }
 }
 ?>

--- a/includes/pipeline.php
+++ b/includes/pipeline.php
@@ -112,8 +112,9 @@ class Pipeline
 
         try {
             $cloud = new CloudRequestEngine([
-                'resourceKey' => $resourceKey,
-                'httpClient'  => new FiftyOneDegreesWpHttpClient(),
+                'resourceKey'        => $resourceKey,
+                'httpClient'         => new FiftyOneDegreesWpHttpClient(),
+                'cloudRequestOrigin' => FiftyOneDegreesWpHttpClient::defaultOrigin(),
             ]);
             // Get engines available with the Resource Key
             $engines = array_keys($cloud->getEngineProperties());

--- a/includes/robots-txt.php
+++ b/includes/robots-txt.php
@@ -286,4 +286,17 @@ class FiftyOneDegreesRobotsTxt {
             exit;
         }
     }
+
+    public static function delete_options() {
+        delete_option(Options::ROBOTS_ENABLE);
+        delete_option(Options::ROBOTS_ENFORCE);
+        delete_option(Options::ROBOTS_REDIRECT_URL);
+        delete_option(Options::ROBOTS_STANDARD_TDL_SELECTED);
+        delete_option(Options::ROBOTS_CUSTOM_TDL);
+        delete_option(Options::ROBOTS_CUSTOM_TOP);
+        delete_option(Options::ROBOTS_CUSTOM_BOTTOM);
+        delete_option(Options::ROBOTS_ALLOWED_CATEGORIES);
+        delete_option(Options::ROBOTS_PLAINTEXT_CACHE);
+        delete_option(Options::ROBOTS_LAST_REFRESH);
+    }
 }

--- a/includes/robots-txt.php
+++ b/includes/robots-txt.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/pipeline.php';
 require_once __DIR__ . '/cloud-metadata.php';
 require_once __DIR__ . '/fiftyone-strings.php';
 require_once __DIR__ . '/standard-tdls.php';
+require_once __DIR__ . '/wp-http-client.php';
 
 use fiftyone\pipeline\cloudrequestengine\CloudRequestEngine;
 use fiftyone\pipeline\cloudrequestengine\CloudRequestException;
@@ -182,7 +183,7 @@ class FiftyOneDegreesRobotsTxt {
             $url .= (strpos($url, '?') !== false ? '&' : '?') . 'client-ip=' . urlencode($ip);
         }
         $httpClient = new FiftyOneDegreesWpHttpClient();
-        return $httpClient->makeCloudRequest('GET', $url, null, null);
+        return $httpClient->makeCloudRequest('GET', $url, null, FiftyOneDegreesWpHttpClient::defaultOrigin());
     }
 
     public static function generate_robots_txt_content($public) {

--- a/includes/suspicious-activity.php
+++ b/includes/suspicious-activity.php
@@ -299,6 +299,13 @@ class SuspiciousActivity
 
         return false;
     }
+
+    public static function delete_options() {
+        delete_option(Options::SUSPICIOUS_ENABLE);
+        delete_option(Options::SUSPICIOUS_REDIRECT_URL);
+        delete_option(Options::SUSPICIOUS_REQUESTS);
+        delete_option(Options::SUSPICIOUS_WINDOW);
+    }
 }
 
 if (function_exists('add_action')) {

--- a/includes/wp-http-client.php
+++ b/includes/wp-http-client.php
@@ -37,6 +37,39 @@ use fiftyone\pipeline\cloudrequestengine\HttpClient;
  */
 class FiftyOneDegreesWpHttpClient extends HttpClient
 {
+    /**
+     * Returns the WP site's own URL formatted as an HTTP Origin header
+     * value (scheme://host[:port], no path), suitable for the
+     * `cloudRequestOrigin` setting / 4th `makeCloudRequest` argument.
+     *
+     * Required for resource keys with a domain restriction set in the
+     * 51Degrees configurator — the cloud compares this against the key's
+     * allow-list. Harmless for unrestricted keys (cloud ignores it).
+     */
+    public static function defaultOrigin(): ?string
+    {
+        if (!function_exists('home_url')) {
+            return null;
+        }
+        try {
+            $home = home_url();
+        } catch (\Throwable $e) {
+            return null;
+        }
+        if (!is_string($home) || $home === '') {
+            return null;
+        }
+        $parts = parse_url($home);
+        if (!is_array($parts) || empty($parts['host'])) {
+            return null;
+        }
+        $scheme = $parts['scheme'] ?? 'https';
+        $host = $parts['host'];
+        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+
+        return $scheme . '://' . $host . $port;
+    }
+
     public function makeCloudRequest(string $type, string $url, ?string $content, ?string $originHeader): string
     {
         // Outside of a loaded WordPress (CI / unit tests, CLI scripts) the WP

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
       <file>tests/SuspiciousActivityTests.php</file>
       <file>tests/RobotsTxtTests.php</file>
       <file>tests/CloudMetadataTests.php</file>
+      <file>tests/PipelineErrorClearTests.php</file>
     </testsuite>
     <testsuite name="Integration">
       <file>tests/PipelineTests.php</file>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
       <file>tests/RobotsTxtTests.php</file>
       <file>tests/CloudMetadataTests.php</file>
       <file>tests/PipelineErrorClearTests.php</file>
+      <file>tests/CloudOriginHeaderTests.php</file>
     </testsuite>
     <testsuite name="Integration">
       <file>tests/PipelineTests.php</file>

--- a/setup.php
+++ b/setup.php
@@ -21,25 +21,30 @@
 
     <?php
 
-        $cachedPipeline = get_option(Options::PIPELINE);
+        $cachedPipeline  = get_option(Options::PIPELINE);
         $validationError = get_option(Options::PIPELINE_VALIDATION_ERROR, '');
+        $resourceKey     = get_option(Options::RESOURCE_KEY, '');
 
-        if (isset($cachedPipeline['error'])) {
-            echo '<p></p><span class="fod-pipeline-status error"><b>' .
-                esc_html($cachedPipeline['error']) . '</b></span>';
-        } elseif (!empty($validationError)) {
-            echo '<p></p><span class="fod-pipeline-status error"><b>' .
-                esc_html($validationError) . '</b></span>';
-        } elseif (isset($cachedPipeline['pipeline'])) {
-            echo '<p></p><span class="fod-pipeline-status good"><b>This ' .
-                'Resource Key is valid and allows access to the custom ' .
-                'properties selected in the following categories: ' .
-                esc_html(json_encode($cachedPipeline['available_engines'])) .
-                ' </br>To continue, connect to Google Analytics via the ' .
-                '<a href="options-general.php?page=51Degrees&tab=google-analytics">' .
-                'Google Analytics</a> tab. See the ' .
-                '<a href="options-general.php?page=51Degrees&tab=properties">Properties</a>' .
-                ' tab for a list of all the custom properties.</b></span>';
+        // Defense-in-depth: only render any status box when a key is actually
+        // configured. Stale state can never bleed through to a fresh UI.
+        if (!empty($resourceKey)) {
+            if (isset($cachedPipeline['error'])) {
+                echo '<p></p><span class="fod-pipeline-status error"><b>' .
+                    esc_html($cachedPipeline['error']) . '</b></span>';
+            } elseif (!empty($validationError)) {
+                echo '<p></p><span class="fod-pipeline-status error"><b>' .
+                    esc_html($validationError) . '</b></span>';
+            } elseif (isset($cachedPipeline['pipeline'])) {
+                echo '<p></p><span class="fod-pipeline-status good"><b>This ' .
+                    'Resource Key is valid and allows access to the custom ' .
+                    'properties selected in the following categories: ' .
+                    esc_html(json_encode($cachedPipeline['available_engines'])) .
+                    ' </br>To continue, connect to Google Analytics via the ' .
+                    '<a href="options-general.php?page=51Degrees&tab=google-analytics">' .
+                    'Google Analytics</a> tab. See the ' .
+                    '<a href="options-general.php?page=51Degrees&tab=properties">Properties</a>' .
+                    ' tab for a list of all the custom properties.</b></span>';
+            }
         }
 
     ?>

--- a/tests/CloudOriginHeaderTests.php
+++ b/tests/CloudOriginHeaderTests.php
@@ -39,31 +39,41 @@ class CloudOriginHeaderTests extends TestCase {
         );
     }
 
-    /** Test that home_url with no path returns the URL unchanged. */
+    /**
+     * Test that home_url with no path returns the URL unchanged.
+     */
     public function testDefaultOrigin_ReturnsSchemeHostForSimpleUrl() {
         Functions\when('home_url')->justReturn('https://example.com');
         $this->assertEquals('https://example.com', FiftyOneDegreesWpHttpClient::defaultOrigin());
     }
 
-    /** Test that home_url with a path is reduced to scheme+host (RFC 6454). */
+    /**
+     * Test that home_url with a path is reduced to scheme+host (RFC 6454).
+     */
     public function testDefaultOrigin_StripsPath() {
         Functions\when('home_url')->justReturn('https://example.com/wp/blog');
         $this->assertEquals('https://example.com', FiftyOneDegreesWpHttpClient::defaultOrigin());
     }
 
-    /** Test that a non-default port is preserved in the Origin value. */
+    /**
+     * Test that a non-default port is preserved in the Origin value.
+     */
     public function testDefaultOrigin_PreservesPort() {
         Functions\when('home_url')->justReturn('http://localhost:8080');
         $this->assertEquals('http://localhost:8080', FiftyOneDegreesWpHttpClient::defaultOrigin());
     }
 
-    /** Test that an unparseable home_url yields null (not a malformed Origin). */
+    /**
+     * Test that an unparseable home_url yields null (not a malformed Origin).
+     */
     public function testDefaultOrigin_ReturnsNullForInvalidHomeUrl() {
         Functions\when('home_url')->justReturn('');
         $this->assertNull(FiftyOneDegreesWpHttpClient::defaultOrigin());
     }
 
-    /** Test that Pipeline::make_pipeline passes Origin to the cloud HTTP layer. */
+    /**
+     * Test that Pipeline::make_pipeline passes Origin to the cloud HTTP layer.
+     */
     public function testMakePipeline_PassesOriginToHttpClient() {
         Functions\when('home_url')->justReturn('https://wp.example.com');
         Functions\when('rest_url')->justReturn('https://wp.example.com/wp-json/fiftyonedegrees/v4/json');
@@ -76,7 +86,9 @@ class CloudOriginHeaderTests extends TestCase {
         $this->assertEquals('https://wp.example.com', $captured);
     }
 
-    /** Test that FiftyOneDegreesCloudMetadata::fetch_accessible_properties passes Origin. */
+    /**
+     * Test that FiftyOneDegreesCloudMetadata::fetch_accessible_properties passes Origin.
+     */
     public function testFetchAccessibleProperties_PassesOriginToHttpClient() {
         Functions\when('home_url')->justReturn('https://wp.example.com');
         Functions\when('get_transient')->justReturn(false);
@@ -91,7 +103,9 @@ class CloudOriginHeaderTests extends TestCase {
         $this->assertEquals('https://wp.example.com', $captured);
     }
 
-    /** Test that FiftyOneDegreesCloudMetadata::fetch_crawler_usage_values passes Origin. */
+    /**
+     * Test that FiftyOneDegreesCloudMetadata::fetch_crawler_usage_values passes Origin.
+     */
     public function testFetchCrawlerUsageValues_PassesOriginToHttpClient() {
         Functions\when('home_url')->justReturn('https://wp.example.com');
         Functions\when('get_transient')->justReturn(false);
@@ -106,7 +120,9 @@ class CloudOriginHeaderTests extends TestCase {
         $this->assertEquals('https://wp.example.com', $captured);
     }
 
-    /** Test that FiftyOneDegreesRobotsTxt::fetch_from_cloud passes Origin. */
+    /**
+     * Test that FiftyOneDegreesRobotsTxt::fetch_from_cloud passes Origin.
+     */
     public function testRobotsTxtFetchFromCloud_PassesOriginToHttpClient() {
         Functions\when('home_url')->justReturn('https://wp.example.com');
         Functions\when('get_transient')->justReturn(false);
@@ -119,6 +135,14 @@ class CloudOriginHeaderTests extends TestCase {
             }
             return $default;
         });
+
+        // Short-circuit the crawler-usage cloud call so the only
+        // makeCloudRequest invocation captured is the robots-txt-specific one.
+        Patchwork\redefine(
+            'FiftyOneDegreesCloudMetadata::fetch_crawler_usage_values',
+            Patchwork\always([])
+        );
+
         $captured = null;
         $this->captureOrigin($captured);
 

--- a/tests/CloudOriginHeaderTests.php
+++ b/tests/CloudOriginHeaderTests.php
@@ -1,0 +1,129 @@
+<?php
+
+require_once(__DIR__ . "/../options.php");
+require_once(__DIR__ . "/../includes/wp-http-client.php");
+require_once(__DIR__ . "/../includes/pipeline.php");
+require_once(__DIR__ . "/../includes/cloud-metadata.php");
+require_once(__DIR__ . "/../includes/robots-txt.php");
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Brain\Monkey\Functions;
+
+class CloudOriginHeaderTests extends TestCase {
+
+    public function set_up() {
+        parent::set_up();
+        Brain\Monkey\setUp();
+        Functions\when('add_filter')->returnArg();
+        Functions\when('add_action')->returnArg();
+    }
+
+    public function tear_down() {
+        Patchwork\undoAll();
+        Brain\Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Helper that captures the 4th arg passed to makeCloudRequest.
+     * Throws a CloudRequestException so callers' error paths fall through
+     * cleanly without us having to mock realistic response bodies.
+     */
+    private function captureOrigin(&$captured) {
+        Patchwork\redefine(
+            'FiftyOneDegreesWpHttpClient::makeCloudRequest',
+            function ($type, $url, $content, $originHeader) use (&$captured) {
+                $captured = $originHeader;
+                throw new \fiftyone\pipeline\cloudrequestengine\CloudRequestException('capture', 0, []);
+            }
+        );
+    }
+
+    /** Test that home_url with no path returns the URL unchanged. */
+    public function testDefaultOrigin_ReturnsSchemeHostForSimpleUrl() {
+        Functions\when('home_url')->justReturn('https://example.com');
+        $this->assertEquals('https://example.com', FiftyOneDegreesWpHttpClient::defaultOrigin());
+    }
+
+    /** Test that home_url with a path is reduced to scheme+host (RFC 6454). */
+    public function testDefaultOrigin_StripsPath() {
+        Functions\when('home_url')->justReturn('https://example.com/wp/blog');
+        $this->assertEquals('https://example.com', FiftyOneDegreesWpHttpClient::defaultOrigin());
+    }
+
+    /** Test that a non-default port is preserved in the Origin value. */
+    public function testDefaultOrigin_PreservesPort() {
+        Functions\when('home_url')->justReturn('http://localhost:8080');
+        $this->assertEquals('http://localhost:8080', FiftyOneDegreesWpHttpClient::defaultOrigin());
+    }
+
+    /** Test that an unparseable home_url yields null (not a malformed Origin). */
+    public function testDefaultOrigin_ReturnsNullForInvalidHomeUrl() {
+        Functions\when('home_url')->justReturn('');
+        $this->assertNull(FiftyOneDegreesWpHttpClient::defaultOrigin());
+    }
+
+    /** Test that Pipeline::make_pipeline passes Origin to the cloud HTTP layer. */
+    public function testMakePipeline_PassesOriginToHttpClient() {
+        Functions\when('home_url')->justReturn('https://wp.example.com');
+        Functions\when('rest_url')->justReturn('https://wp.example.com/wp-json/fiftyonedegrees/v4/json');
+
+        $captured = null;
+        $this->captureOrigin($captured);
+
+        Pipeline::make_pipeline('TEST_KEY');
+
+        $this->assertEquals('https://wp.example.com', $captured);
+    }
+
+    /** Test that FiftyOneDegreesCloudMetadata::fetch_accessible_properties passes Origin. */
+    public function testFetchAccessibleProperties_PassesOriginToHttpClient() {
+        Functions\when('home_url')->justReturn('https://wp.example.com');
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('delete_transient')->justReturn(true);
+        Functions\when('get_option')->justReturn('some-key');
+        $captured = null;
+        $this->captureOrigin($captured);
+
+        FiftyOneDegreesCloudMetadata::fetch_accessible_properties();
+
+        $this->assertEquals('https://wp.example.com', $captured);
+    }
+
+    /** Test that FiftyOneDegreesCloudMetadata::fetch_crawler_usage_values passes Origin. */
+    public function testFetchCrawlerUsageValues_PassesOriginToHttpClient() {
+        Functions\when('home_url')->justReturn('https://wp.example.com');
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('delete_transient')->justReturn(true);
+        Functions\when('get_option')->justReturn('some-key');
+        $captured = null;
+        $this->captureOrigin($captured);
+
+        FiftyOneDegreesCloudMetadata::fetch_crawler_usage_values();
+
+        $this->assertEquals('https://wp.example.com', $captured);
+    }
+
+    /** Test that FiftyOneDegreesRobotsTxt::fetch_from_cloud passes Origin. */
+    public function testRobotsTxtFetchFromCloud_PassesOriginToHttpClient() {
+        Functions\when('home_url')->justReturn('https://wp.example.com');
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('delete_transient')->justReturn(true);
+        Functions\when('update_option')->justReturn(true);
+        Functions\when('get_option')->alias(function ($key, $default = false) {
+            if ($key === Options::RESOURCE_KEY) {
+                return 'some-key';
+            }
+            return $default;
+        });
+        $captured = null;
+        $this->captureOrigin($captured);
+
+        FiftyOneDegreesRobotsTxt::fetch_from_cloud();
+
+        $this->assertEquals('https://wp.example.com', $captured);
+    }
+}

--- a/tests/PipelineErrorClearTests.php
+++ b/tests/PipelineErrorClearTests.php
@@ -1,0 +1,114 @@
+<?php
+
+require_once(__DIR__ . "/../includes/pipeline.php");
+require_once(__DIR__ . "/../includes/fiftyone-service.php");
+require_once(__DIR__ . "/TestFlowElement.php");
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Brain\Monkey\Functions;
+
+class PipelineErrorClearTests extends TestCase {
+
+    public function set_up() {
+        parent::set_up();
+        Brain\Monkey\setUp();
+        Functions\when('add_filter')->returnArg();
+        Functions\when('add_action')->returnArg();
+    }
+
+    public function tear_down() {
+        Patchwork\undoAll();
+        Brain\Monkey\tearDown();
+        parent::tear_down();
+    }
+
+    /**
+     * Test that build_and_save_pipeline() short-circuits cleanly when the
+     * resource key is empty: it must not call Pipeline::make_pipeline (no
+     * cloud round-trip), and it must clear any leftover error state.
+     */
+    public function testBuildAndSavePipeline_EmptyKeySkipsValidationAndClearsState() {
+        $optionStore = [
+            Options::PIPELINE => ['error' => 'old failure'],
+            Options::PIPELINE_VALIDATION_ERROR => 'old validation error',
+        ];
+
+        Functions\when('get_option')->alias(function($k, $default = false) use (&$optionStore) {
+            return array_key_exists($k, $optionStore) ? $optionStore[$k] : $default;
+        });
+        Functions\when('update_option')->alias(function($k, $v) use (&$optionStore) {
+            $optionStore[$k] = $v;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function($k) use (&$optionStore) {
+            unset($optionStore[$k]);
+            return true;
+        });
+
+        $makePipelineCalled = false;
+        Patchwork\redefine(
+            'Pipeline::make_pipeline',
+            function($key) use (&$makePipelineCalled) {
+                $makePipelineCalled = true;
+                return ['pipeline' => null, 'available_engines' => null, 'error' => 'unexpected'];
+            }
+        );
+
+        $reflection = new \ReflectionMethod(FiftyoneService::class, 'build_and_save_pipeline');
+        $reflection->setAccessible(true);
+        $reflection->invoke(null, '');
+
+        $this->assertFalse(
+            $makePipelineCalled,
+            'Empty resource key must not trigger a cloud call via make_pipeline.'
+        );
+        $this->assertArrayNotHasKey(
+            Options::PIPELINE,
+            $optionStore,
+            'Empty key must clear Options::PIPELINE so no stale error survives.'
+        );
+        $this->assertArrayNotHasKey(
+            Options::PIPELINE_VALIDATION_ERROR,
+            $optionStore,
+            'Empty key must clear Options::PIPELINE_VALIDATION_ERROR.'
+        );
+    }
+
+    /**
+     * Test that setup.php does not render any error or success box when
+     * the resource key is empty, even if stale option state would
+     * otherwise produce one. Defense-in-depth render-side guard.
+     */
+    public function testSetupTab_NoStatusBoxWhenResourceKeyEmpty() {
+        $optionStore = [
+            Options::RESOURCE_KEY              => '',
+            Options::PIPELINE                  => null,
+            Options::PIPELINE_VALIDATION_ERROR => 'stale validation error',
+            Options::PIPELINE_ENABLE           => 'on',
+        ];
+
+        Functions\when('get_option')->alias(function($k, $default = false) use (&$optionStore) {
+            return array_key_exists($k, $optionStore) ? $optionStore[$k] : $default;
+        });
+        Functions\when('settings_fields')->justReturn(null);
+        Functions\when('esc_attr')->returnArg();
+        Functions\when('esc_html')->returnArg();
+        Functions\when('checked')->justReturn('checked="checked"');
+
+        ob_start();
+        include __DIR__ . '/../setup.php';
+        $output = ob_get_clean();
+
+        $this->assertStringNotContainsString(
+            'fod-pipeline-status error',
+            $output,
+            'No red status box may render when resource key is empty.'
+        );
+        $this->assertStringNotContainsString(
+            'fod-pipeline-status good',
+            $output,
+            'No green status box may render when resource key is empty.'
+        );
+    }
+}
+?>


### PR DESCRIPTION
See #50 

**51Degrees plugin — setup, origin, and clean uninstall**

Three fixes on this branch:

1. **Cloud calls send an `Origin` header** (derived from `home_url()`). Required for resource keys with a domain restriction in the 51Degrees configurator — without it, those keys were rejected. No-op for unrestricted keys.

2. **Setup tab guards against an empty resource key.** No more spurious errors during first-time configuration.

3. **Clean deactivate/uninstall.** Previously the plugin left robots rules, cached robots preview, suspicious thresholds, pipeline flag, cloud response caches, and stuck failure state behind in `wp_options`. Refactored `Fiftyonedegrees::delete_options()` into per-subsystem cleanup (GA + pipeline + suspicious + robots), and the deactivate handler also calls `FiftyOneDegreesCloudMetadata::invalidate_all()` to drop cloud-metadata success caches and failure-backoff timers.

**Side effect:** the red "Cloud unreachable" banner no longer lingers — it clears on a successful refresh, on a resource-key change, on deactivate/uninstall, or after the circuit-breaker window expires (≤ 1 h).

**Affects**
- New installs: clean by default; domain-restricted keys work out of the box.
- Existing installs upgrading: origin + setup-tab fixes apply on update. Cleanup applies only on user-initiated deactivate (WordPress doesn't fire that hook during normal plugin updates). Deactivate + reactivate for a clean slate.
