### PR TITLE
Fix #60: keep /robots.txt reachable to crawlers despite enforce policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.phpunit.result.cache

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,5 @@
+= 1.0.12 =
+* FIX: /robots.txt is now always reachable to crawlers regardless of the configured robots-enforce policy. Previously, disallowed crawlers were 302-redirected when fetching /robots.txt itself, defeating the policy the file advertises (issue #60).
+
 = 1.0 =
 * Initial Release.

--- a/fiftyonedegrees.php
+++ b/fiftyonedegrees.php
@@ -3,7 +3,7 @@
  *  Plugin Name: 51Degrees
  *  Plugin URI:  https://51degrees.com/
  *  Description: Device detection and location-aware content for WordPress, with cloud-driven robots.txt management for AI/search crawlers and suspicious-activity protection against abusive traffic.
- *  Version:     1.0.11
+ *  Version:     1.0.12
  *  Author:      51Degrees
  *  Author URI:  https://51degrees.com/
  *  Text Domain: fiftyonedegrees

--- a/includes/robots-txt.php
+++ b/includes/robots-txt.php
@@ -238,6 +238,14 @@ class FiftyOneDegreesRobotsTxt {
             return;
         }
 
+        // /robots.txt must be reachable to crawlers regardless of crawler-
+        // category gating; redirecting it defeats the policy it advertises.
+        // Mirrors the matching skip in suspicious-activity.php.
+        $path = wp_parse_url(wp_unslash($_SERVER['REQUEST_URI'] ?? '/'), PHP_URL_PATH);
+        if (is_string($path) && strtolower(rtrim($path, '/')) === '/robots.txt') {
+            return;
+        }
+
         $is_crawler = Pipeline::get('device', 'iscrawler');
         if ($is_crawler !== true) {
             return;

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: 51degrees, device detection, location, Google Analytics, device, detect, d
 Requires at least: 4.7
 Tested up to: 6.9.1
 Requires PHP: 8.2
-Stable tag: 1.0.0
+Stable tag: 1.0.12
 License: EUPL
 
 The best plugin for WordPress to send Device properties as Custom Dimensions to Google Analytics to get richer insights of device specifications and capabilities.
@@ -103,6 +103,9 @@ You can continue using your existing installed plugins to send Custom Dimensions
 If you're experiencing any issues, use the WordPress.org [support forums](https://wordpress.org/support/plugin/51degrees-optimize-by-device-location/). If you have a technical issue with the plugin where you already have more insight on how to fix it, you can also open an issue on [GitHub](https://github.com/51Degrees/pipeline-wordpress/issues).
 
 == Changelog ==
+
+= 1.0.12 =
+* FIX: /robots.txt is now always reachable to crawlers regardless of the configured robots-enforce policy. Previously, disallowed crawlers were 302-redirected when fetching /robots.txt itself, defeating the policy the file advertises (issue #60).
 
 = 1.0.0 =
 * Initial Release.

--- a/tests/RobotsTxtTests.php
+++ b/tests/RobotsTxtTests.php
@@ -155,6 +155,10 @@ class RobotsTxtTests extends TestCase {
     private function mockGuardsPassed() {
         Functions\when('is_admin')->justReturn(false);
         Patchwork\redefine('php_sapi_name', Patchwork\always('apache2handler'));
+        Functions\when('wp_parse_url')->alias(function ($url, $component = -1) {
+            return parse_url($url, $component);
+        });
+        Functions\when('wp_unslash')->returnArg();
     }
 
     public function testEnforceSkippedWhenPipelineDisabled() {
@@ -362,6 +366,108 @@ class RobotsTxtTests extends TestCase {
         FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
 
         $this->assertFalse($redirected);
+    }
+
+    /**
+     * Helper: stage a configuration where enforce_crawler_redirect() would
+     * redirect (disallowed crawler) and capture whether wp_redirect fires.
+     * Used by the /robots.txt exclusion tests (#60).
+     */
+    private function stageDisallowedCrawlerCapture(&$redirected) {
+        $this->mockGuardsPassed();
+        $this->mockOptions([
+            Options::ROBOTS_ENFORCE => 'on',
+            Options::ROBOTS_ALLOWED_CATEGORIES => array_diff(self::ALL_TEST_CATEGORIES, ['Search']),
+            Options::ROBOTS_REDIRECT_URL => 'https://example.com/denied',
+            Options::ROBOTS_PLAINTEXT_CACHE => "User-agent: *\nDisallow: /\n",
+        ]);
+        Patchwork\redefine('Pipeline::get', function ($engine, $prop) {
+            if ($prop === 'iscrawler') return true;
+            if ($prop === 'crawlerusage') return ['Search'];
+            return null;
+        });
+        Patchwork\redefine(
+            'FiftyOneDegreesCloudMetadata::supports_crawler_usage',
+            Patchwork\always(true)
+        );
+        Patchwork\redefine('exit', Patchwork\always(null));
+
+        Functions\when('sanitize_text_field')->returnArg();
+        Functions\when('wp_unslash')->returnArg();
+
+        $redirected = false;
+        Functions\when('wp_redirect')->alias(function () use (&$redirected) {
+            $redirected = true;
+        });
+    }
+
+    public function testEnforceCrawlerRedirectSkipsRobotsTxtPath() {
+        // Issue #60: /robots.txt must be reachable to crawlers regardless of
+        // the crawler-category gate, otherwise the policy contradicts itself.
+        $this->stageDisallowedCrawlerCapture($redirected);
+        $_SERVER['REQUEST_URI'] = '/robots.txt';
+
+        FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
+
+        $this->assertFalse($redirected);
+    }
+
+    public function testEnforceCrawlerRedirectSkipsRobotsTxtWithQueryString() {
+        $this->stageDisallowedCrawlerCapture($redirected);
+        $_SERVER['REQUEST_URI'] = '/robots.txt?ver=1';
+
+        FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
+
+        $this->assertFalse($redirected);
+    }
+
+    public function testEnforceCrawlerRedirectSkipsRobotsTxtCaseInsensitive() {
+        $this->stageDisallowedCrawlerCapture($redirected);
+        $_SERVER['REQUEST_URI'] = '/Robots.TXT';
+
+        FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
+
+        $this->assertFalse($redirected);
+    }
+
+    public function testEnforceCrawlerRedirectSkipsRobotsTxtTrailingSlash() {
+        $this->stageDisallowedCrawlerCapture($redirected);
+        $_SERVER['REQUEST_URI'] = '/robots.txt/';
+
+        FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
+
+        $this->assertFalse($redirected);
+    }
+
+    public function testEnforceCrawlerRedirectHandlesMissingRequestUri() {
+        // Covers the `?? '/'` fallback when $_SERVER['REQUEST_URI'] is unset
+        // (some SAPI configs / CLI-like contexts). '/' is not /robots.txt so
+        // enforcement proceeds normally and the disallowed crawler is redirected.
+        $this->stageDisallowedCrawlerCapture($redirected);
+        unset($_SERVER['REQUEST_URI']);
+        Functions\when('home_url')->justReturn('https://example.com/');
+        Functions\when('trailingslashit')->alias(function ($u) {
+            return rtrim($u, '/') . '/';
+        });
+
+        FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
+
+        $this->assertTrue($redirected);
+    }
+
+    public function testEnforceCrawlerRedirectStillFiresOnOtherPaths() {
+        // Regression sanity for the /robots.txt early-return: the guard must
+        // only match the exact path, not substrings or unrelated URLs.
+        $this->stageDisallowedCrawlerCapture($redirected);
+        $_SERVER['REQUEST_URI'] = '/about/robots.txt-explained';
+        Functions\when('home_url')->justReturn('https://example.com/about/robots.txt-explained');
+        Functions\when('trailingslashit')->alias(function ($u) {
+            return rtrim($u, '/') . '/';
+        });
+
+        FiftyOneDegreesRobotsTxt::enforce_crawler_redirect();
+
+        $this->assertTrue($redirected);
     }
 
     public function testRedirectLoopPreventionSkipsRedirect() {


### PR DESCRIPTION
Summary

Fixes #60. enforce_crawler_redirect() had no exception for /robots.txt, so disallowed crawlers were 302'd away from the very policy file they asked for. Adds an early return mirroring the existing skip in suspicious-activity.php.

What changed

- includes/robots-txt.php — early return for REQUEST_URI = /robots.txt (case-insensitive, query/trailing-slash tolerant) before the pipeline crawler lookup.
- tests/RobotsTxtTests.php — 6 new tests; shared wp_parse_url/wp_unslash mocks moved into mockGuardsPassed().
- Version bump 1.0.11 → 1.0.12 + changelog entries; Stable tag synced.

Note

Subdir multisite (/siteN/robots.txt) still falls through — same limitation as the mirrored suspicious-activity.php skip, will broaden both together if it comes up.