### PR TITLE
Fix #61: skip PMP enqueue on configured alt-button and terms pages

### DIFF
--- a/includes/fiftyone-service.php
+++ b/includes/fiftyone-service.php
@@ -759,6 +759,15 @@ class FiftyoneService {
             return;
         }
 
+        // Issue #61: skip enqueue on the configured alt-button destination and
+        // terms/privacy pages — those are special-case for TCF/PMP (the visitor
+        // either landed there AS an alternative to PMP, or clicked the popup's
+        // own terms link to read them; wrapping such pages with PMP again is a
+        // UX/legal contradiction).
+        if (self::current_page_is_pmp_exempt()) {
+            return;
+        }
+
         // Footer load: PMP attaches its popup container as a sibling of this
         // script tag (see view.ts getRoot()). In <head> that container would
         // be unrenderable (head has display:none).
@@ -806,6 +815,85 @@ class FiftyoneService {
             '%s/api/v4/pmp?resource=%s',
             FiftyOneDegreesCloudMetadata::get_cloud_host_url(),
             rawurlencode($key));
+    }
+
+    /**
+     * Returns true when the current request matches the page configured as
+     * PMP_ALT_URL (alternative-button destination) or PMP_BRAND_TERMS_URL
+     * (terms/privacy linked from the PMP popup). On those pages the PMP
+     * script must not be enqueued — see issue #61.
+     *
+     * Match strategy mirrors SuspiciousActivity::is_on_redirect_target():
+     * post-ID match first (handles internal pages with pretty permalinks),
+     * canonical path match as fallback (handles trailing slash, query string,
+     * full-URL option storage).
+     *
+     * Returns false when both options are empty or normalize to '/' — a
+     * root-path target would otherwise exempt every page on the site.
+     *
+     * The result is filterable via 'fiftyonedegrees_pmp_exempt' so sites
+     * with i18n plugins (WPML / TranslatePress) can broaden the match
+     * across translated slugs.
+     */
+    private static function current_page_is_pmp_exempt() {
+        $targets = array_filter([
+            get_option(Options::PMP_ALT_URL),
+            get_option(Options::PMP_BRAND_TERMS_URL),
+        ]);
+
+        // Drop targets that normalize to root '/' — treating those as
+        // configured would exempt every page on the site (foot-gun guard).
+        $targets = array_filter($targets, function ($t) {
+            $p = trailingslashit(wp_parse_url($t, PHP_URL_PATH) ?: '/');
+            return strtolower($p) !== '/';
+        });
+
+        if (empty($targets)) {
+            return false;
+        }
+
+        $current_uri = wp_unslash($_SERVER['REQUEST_URI'] ?? '/');
+        $current_path = strtolower(rawurldecode(trailingslashit(strtok($current_uri, '?'))));
+        $current_id = function_exists('url_to_postid') && function_exists('home_url')
+            ? (int) url_to_postid(home_url($current_uri))
+            : 0;
+
+        // Subdir multisite / WP-in-subdir: REQUEST_URI starts with the site's
+        // path prefix (e.g. '/blog/terms/'), while an option stored as a path-
+        // only value ('/terms') would not. Also expose a stripped variant so
+        // both shapes match. Single-site $home_path is '/' and stripping is
+        // a no-op.
+        $home_path = function_exists('home_url')
+            ? strtolower(trailingslashit(wp_parse_url(home_url('/'), PHP_URL_PATH) ?: '/'))
+            : '/';
+        $current_path_stripped = ($home_path !== '/' && str_starts_with($current_path, $home_path))
+            ? '/' . substr($current_path, strlen($home_path))
+            : $current_path;
+
+        $match = false;
+        foreach ($targets as $target) {
+            if ($current_id > 0) {
+                $target_id = (int) url_to_postid($target);
+                if ($target_id > 0 && $current_id === $target_id) {
+                    $match = true;
+                    break;
+                }
+            }
+            $target_path = strtolower(rawurldecode(trailingslashit(wp_parse_url($target, PHP_URL_PATH) ?: '/')));
+            if ($current_path === $target_path || $current_path_stripped === $target_path) {
+                $match = true;
+                break;
+            }
+        }
+
+        /**
+         * Filter the PMP-exempt decision.
+         *
+         * @param bool   $match        Whether the current request matches an exempt URL.
+         * @param string $current_path Canonical lowercased trailing-slashed path of the current request.
+         * @param array  $targets      Non-empty exempt URLs (after the foot-gun filter).
+         */
+        return (bool) apply_filters('fiftyonedegrees_pmp_exempt', $match, $current_path, $targets);
     }
 
     /**

--- a/includes/suspicious-activity.php
+++ b/includes/suspicious-activity.php
@@ -272,6 +272,12 @@ class SuspiciousActivity
      * /page-slug/ to / for the home request, and a plain path comparison
      * would treat them as different and loop.
      *
+     * Note: FiftyoneService::current_page_is_pmp_exempt() (issue #61) does
+     * structurally similar URL-vs-options matching with a couple of bug-
+     * fix improvements (lowercase + URL-decode + root foot-gun guard +
+     * subdir-multisite path stripping). If a third call-site appears the
+     * two should be consolidated into a shared helper.
+     *
      * @access private
      *
      * @return bool

--- a/tests/HookTests.php
+++ b/tests/HookTests.php
@@ -222,9 +222,296 @@ class HookTests extends TestCase {
             ->with("fiftyonedegrees", Mockery::any(), "before");
 
         (new FiftyoneService())->fiftyonedegrees_javascript();
-       
+
         // We are asserting via the expect, so tell PHPUnit not
         // to worry.
+        $this->assertTrue(true);
+    }
+
+    // ====================================================================
+    // Issue #61 — PMP exemption on alt-button / terms pages
+    // ====================================================================
+
+    /**
+     * Common environment for the PMP-enqueue tests: PMP enabled, valid
+     * resource key, both PMP page options point at internal paths, plus
+     * stubs for the WP helpers used by current_page_is_pmp_exempt() and
+     * by the PMP enqueue block itself.
+     *
+     * url_to_postid defaults to 0 (no internal-post match) so the
+     * exemption decision falls through to canonical-path comparison —
+     * individual tests override this when they need a post-ID match.
+     *
+     * @param array  $optionOverrides  per-test option overrides
+     * @param string $requestUri       value placed in $_SERVER['REQUEST_URI']
+     */
+    private function stagePmpEnqueueEnv(array $optionOverrides = [], string $requestUri = '/about', bool $stubEnqueueHelpers = true) {
+        $options = array_merge([
+            Options::PMP_ENABLE         => 'on',
+            Options::RESOURCE_KEY       => 'valid-resource-key',
+            Options::PMP_ALT_URL        => '/subscribe',
+            Options::PMP_BRAND_TERMS_URL => '/terms',
+        ], $optionOverrides);
+
+        Functions\when('get_option')->alias(function ($arg, $default = null) use ($options) {
+            if (array_key_exists($arg, $options)) {
+                return $options[$arg];
+            }
+            if ($arg === Options::PIPELINE) {
+                return HookTests::$pipeline;
+            }
+            return $default;
+        });
+
+        Functions\when('plugin_dir_url')->justReturn('root/includes/');
+        Functions\when('home_url')->alias(function ($p = '/') {
+            return 'https://example.com' . $p;
+        });
+        Functions\when('trailingslashit')->alias(function ($u) {
+            return rtrim($u, '/') . '/';
+        });
+        Functions\when('wp_parse_url')->alias(function ($url, $component = -1) {
+            return parse_url($url, $component);
+        });
+        Functions\when('wp_unslash')->returnArg();
+        Functions\when('url_to_postid')->justReturn(0);
+        Functions\when('apply_filters')->alias(function ($tag, $value) {
+            return $value;
+        });
+        Functions\when('add_filter')->justReturn(true);
+
+        // fod.js + Pipeline JS are enqueued unconditionally above the PMP
+        // block; most PMP tests don't assert on those, so allow them through.
+        // testFodJsStillEnqueuedOnPmpExemptPage sets strict expectations and
+        // opts out of these default stubs.
+        if ($stubEnqueueHelpers) {
+            Functions\when('wp_enqueue_script')->justReturn(null);
+            Functions\when('wp_add_inline_script')->justReturn(null);
+        }
+
+        $_SERVER['REQUEST_URI'] = $requestUri;
+    }
+
+    private function expectPmpRegistered() {
+        Functions\expect('wp_register_script')
+            ->once()
+            ->with('fiftyonedegrees-pmp', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any());
+    }
+
+    private function expectPmpNotRegistered() {
+        Functions\expect('wp_register_script')->never();
+    }
+
+    public function testPmpEnqueuedOnNormalPage() {
+        $this->stagePmpEnqueueEnv([], '/about');
+        $this->expectPmpRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedOnAltUrlPage() {
+        $this->stagePmpEnqueueEnv([], '/subscribe');
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedOnTermsUrlPage() {
+        $this->stagePmpEnqueueEnv([], '/terms');
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedOnAltUrlTrailingSlashVariation() {
+        $this->stagePmpEnqueueEnv([Options::PMP_ALT_URL => '/subscribe'], '/subscribe/');
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedOnAltUrlWithQueryString() {
+        $this->stagePmpEnqueueEnv([Options::PMP_ALT_URL => '/subscribe'], '/subscribe?utm_source=x');
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedWhenOptionStoredAsFullUrl() {
+        // Production storage form — admin pastes the canonical full URL
+        // from their address bar instead of a path-only value.
+        $this->stagePmpEnqueueEnv(
+            [Options::PMP_ALT_URL => 'https://example.com/subscribe/'],
+            '/subscribe'
+        );
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedCaseInsensitive() {
+        $this->stagePmpEnqueueEnv([Options::PMP_ALT_URL => '/Subscribe'], '/subscribe');
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpEnqueuedWhenAltUrlIsExternal() {
+        // External URL in PMP_ALT_URL — the current request is by definition
+        // on this site, so the paths can't collide.
+        $this->stagePmpEnqueueEnv(
+            [
+                Options::PMP_ALT_URL         => 'https://external-paywall.example.org/checkout',
+                Options::PMP_BRAND_TERMS_URL => '',
+            ],
+            '/about'
+        );
+        $this->expectPmpRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpEnqueuedWhenBothPmpOptionsEmpty() {
+        $this->stagePmpEnqueueEnv(
+            [Options::PMP_ALT_URL => '', Options::PMP_BRAND_TERMS_URL => ''],
+            '/subscribe'
+        );
+        $this->expectPmpRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpEnqueuedWhenAltUrlIsRoot() {
+        // Foot-gun guard: PMP_ALT_URL='/' (or full home URL) would otherwise
+        // exempt every page on the site. Treat as misconfigured.
+        $this->stagePmpEnqueueEnv(
+            [Options::PMP_ALT_URL => '/', Options::PMP_BRAND_TERMS_URL => 'https://example.com/'],
+            '/about'
+        );
+        $this->expectPmpRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpEnqueuedOnCategoryArchive() {
+        // Archive / category / search URLs return url_to_postid() = 0, so
+        // the exemption falls through to canonical-path match. The archive
+        // path doesn't collide with any configured page → PMP fires.
+        $this->stagePmpEnqueueEnv([], '/category/news');
+        $this->expectPmpRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedByPostIdMatchEvenIfPathsDiffer() {
+        // Same post served under two URLs (e.g. permalink rewrite, /?p=N
+        // pretty-URL aliasing). url_to_postid() collapses both sides to
+        // the same ID — PMP must be exempted.
+        $this->stagePmpEnqueueEnv(
+            [Options::PMP_ALT_URL => '/new-slug', Options::PMP_BRAND_TERMS_URL => ''],
+            '/old-slug'
+        );
+        // Override stagePmpEnqueueEnv's default url_to_postid stub (0) so
+        // both the current URI and the target option resolve to the same
+        // post ID, exercising the post-ID branch of the matcher.
+        Functions\when('url_to_postid')->justReturn(42);
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testFodJsStillEnqueuedOnPmpExemptPage() {
+        // Sanity: on a PMP-exempt page the PMP script is gated off, but
+        // fod.js + Pipeline::getJavaScript() must still be enqueued.
+        $this->stagePmpEnqueueEnv([], '/subscribe', false);
+        $this->expectPmpNotRegistered();
+
+        Functions\expect('wp_enqueue_script')
+            ->once()
+            ->with('fiftyonedegrees', 'root/includes/../assets/js/fod.js');
+        Functions\expect('wp_add_inline_script')
+            ->once()
+            ->with('fiftyonedegrees', Mockery::any(), 'before');
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpSkippedOnSubdirMultisiteWithPathOnlyOption() {
+        // Issue #61 + reviewer R-1: on subdir multisite REQUEST_URI starts
+        // with the site path prefix ('/blog/terms/') while a path-only
+        // option stays '/terms'. The matcher exposes a home-stripped
+        // current path so both shapes still match.
+        $this->stagePmpEnqueueEnv(
+            [Options::PMP_ALT_URL => '/terms', Options::PMP_BRAND_TERMS_URL => ''],
+            '/blog/terms'
+        );
+        // home_url('/') returns the subsite root including the path prefix.
+        Functions\when('home_url')->alias(function ($p = '/') {
+            return 'https://example.com/blog' . $p;
+        });
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testExemptCheckSkippedWhenPmpDisabled() {
+        // Ordering guarantee: when PMP_ENABLE='off' the function must short-
+        // circuit BEFORE current_page_is_pmp_exempt() runs — otherwise we
+        // pay url_to_postid + option reads on every front-end request on
+        // sites that don't use PMP at all.
+        $this->stagePmpEnqueueEnv([Options::PMP_ENABLE => 'off'], '/about');
+        Functions\expect('url_to_postid')->never();
+        $this->expectPmpNotRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
+        $this->assertTrue(true);
+    }
+
+    public function testPmpExemptFilterCanForceFalse() {
+        // The fiftyonedegrees_pmp_exempt filter lets sites with i18n
+        // plugins (or any custom logic) override the path/ID-match result.
+        // Forcing the filter to return false re-enables PMP on an
+        // otherwise-exempt page.
+        $this->stagePmpEnqueueEnv([], '/subscribe');
+        Functions\when('apply_filters')->alias(function ($tag, $value) {
+            if ($tag === 'fiftyonedegrees_pmp_exempt') {
+                return false;
+            }
+            return $value;
+        });
+        $this->expectPmpRegistered();
+
+        (new FiftyoneService())->fiftyonedegrees_javascript();
+
         $this->assertTrue(true);
     }
 


### PR DESCRIPTION
Summary

Fixes #61. The PMP popup currently appears also on the pages configured as PMP_ALT_URL (alt-button destination) and PMP_BRAND_TERMS_URL (terms linked from the popup itself) — contradicting TCF semantics, since those pages must be reachable either before accepting PMP or as an alternative to PMP.

Adds a new FiftyoneService::current_page_is_pmp_exempt() helper and gates wp_register_script('fiftyonedegrees-pmp', ...) on it. fod.js and the inline Pipeline JS remain enqueued on exempt pages.

What changed

- includes/fiftyone-service.php — new private static helper + one-line gate inside fiftyonedegrees_javascript(). Match strategy mirrors SuspiciousActivity::is_on_redirect_target(): post-ID match via url_to_postid with canonical path match as fallback. Path normalization: wp_unslash + rawurldecode + strtolower + trailingslashit. Foot-gun guard drops options that normalize to / (would otherwise exempt every page). Subdir-multisite variant of the current path so path-only options still match when REQUEST_URI carries the site prefix.
- includes/suspicious-activity.php — 6-line docblock note pointing at the new helper and documenting the bug-fix divergences (lowercase / URL-decode / root-guard / subdir-strip), per cross-reference policy.
- tests/HookTests.php — 16 new unit tests + setup helpers stagePmpEnqueueEnv, expectPmpRegistered, expectPmpNotRegistered.

Extensibility

Result is filterable via apply_filters('fiftyonedegrees_pmp_exempt', $match, $current_path, $targets) so sites with i18n plugins (WPML / TranslatePress) can broaden the match across translated slugs.