### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Pipeline API
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_campaign=varnish_open_source&utm_content=readme_main "Data rewards the curious") **Pipeline API - WordPress plugin**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.md&utm_term=51degrees-pipeline-api "Data rewards the curious") **Pipeline API - WordPress plugin**
 
-[Developer Documentation](https://51degrees.com/device-detection-php/md__home_vsts_work_1_s_apis_device-detection-php_readme.html "Developer Documentation")
+[Developer Documentation](https://51degrees.com/device-detection-php/md__home_vsts_work_1_s_apis_device-detection-php_readme.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.md&utm_term=51degrees-pipeline-api "Developer Documentation")
 # Introduction
 Optimize your website for a range of devices and personalize your content
 based on your user’s location.
@@ -19,7 +19,7 @@ by searching for `51Degrees`.
 2. To start using this plugin, you will need to create a `Resource Key`.
 This enables access to the data you need via the 51Degrees cloud service.
 You can create a `Resource Key` for free, using the
-[configurator](https://configure.51degrees.com/) to select the properties
+[configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.md&utm_term=after-activation) to select the properties
 you want.
 
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,5 +4,5 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`

--- a/fiftyonedegrees.php
+++ b/fiftyonedegrees.php
@@ -1,11 +1,11 @@
 <?php
 /**
  *  Plugin Name: 51Degrees
- *  Plugin URI:  https://51degrees.com/
+ *  Plugin URI:  https://51degrees.com/?utm_source=packagist&utm_medium=package&utm_campaign=pipeline-wordpress&utm_content=fiftyonedegrees.php&utm_term=plugin-uri
  *  Description: Device detection and location-aware content for WordPress, with cloud-driven robots.txt management for AI/search crawlers and suspicious-activity protection against abusive traffic.
  *  Version:     1.0.12
  *  Author:      51Degrees
- *  Author URI:  https://51degrees.com/
+ *  Author URI:  https://51degrees.com/?utm_source=packagist&utm_medium=package&utm_campaign=pipeline-wordpress&utm_content=fiftyonedegrees.php&utm_term=author-uri
  *  Text Domain: fiftyonedegrees
  *  License:     EUPL-1.2
  *

--- a/help.php
+++ b/help.php
@@ -80,7 +80,7 @@
 
 <p>
     Please visit our
-    <a href="https://51degrees.com/documentation/_other_integrations__wordpress.html" target="_blank">
+    <a href="https://51degrees.com/documentation/_other_integrations__wordpress.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=help.php&utm_term=use-in-templates-and-advanced-features" target="_blank">
         documentation
     </a>
     page for more information on advanced features including Value Replacement

--- a/includes/fiftyone-service.php
+++ b/includes/fiftyone-service.php
@@ -1,11 +1,11 @@
 <?php
 /**
  *  Plugin Name: 51Degrees
- *  Plugin URI:  https://51degrees.com/
+ *  Plugin URI:  https://51degrees.com/?utm_source=packagist&utm_medium=package&utm_campaign=pipeline-wordpress&utm_content=includes-fiftyone-service.php&utm_term=plugin-uri
  *  Description: Device detection and location-aware content for WordPress, with cloud-driven robots.txt management for AI/search crawlers and suspicious-activity protection against abusive traffic.
  *  Version:     1.0.11
  *  Author:      51Degrees
- *  Author URI:  https://51degrees.com/
+ *  Author URI:  https://51degrees.com/?utm_source=packagist&utm_medium=package&utm_campaign=pipeline-wordpress&utm_content=includes-fiftyone-service.php&utm_term=author-uri
  *  Text Domain: fiftyonedegrees
  *  License:     EUPL-1.2
  *

--- a/includes/pipeline.php
+++ b/includes/pipeline.php
@@ -240,7 +240,7 @@ class Pipeline
 
                 $flowData->process();
 
-                // https://51degrees.com/blog/user-agent-client-hints
+                // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=includes-pipeline.php&utm_term=process
                 Utils::setResponseHeader($flowData);
 
                 // Prefer the cloud's entitlement map cached at build time:

--- a/languages/common-strings.yaml
+++ b/languages/common-strings.yaml
@@ -11,6 +11,6 @@ common:
 
   cloud:
     # (HTML) Shown when the cloud responded with a non-2xx status (e.g. 400 errors-envelope, 401 expired key, 5xx).
-    rejected: '<strong>51Degrees Cloud rejected the request.</strong> Check your resource key and subscription at <a href="https://configure.51degrees.com/" target="_blank">configure.51degrees.com</a>.'
+    rejected: '<strong>51Degrees Cloud rejected the request.</strong> Check your resource key and subscription at <a href="https://configure.51degrees.com/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=languages-common-strings.yaml&utm_term=rejected" target="_blank">configure.51degrees.com</a>.'
     # (HTML) Shown when the cloud is unreachable (network failure / timeout).
     unreachable: '<strong>51Degrees Cloud unreachable.</strong> The plugin will retry automatically.'

--- a/languages/robots-strings.yaml
+++ b/languages/robots-strings.yaml
@@ -23,11 +23,11 @@ robots:
 
   notice:
     # (HTML) Shown when the resource key lacks IsCrawler / CrawlerUsage properties.
-    no_crawler: '<strong>Warning:</strong> Your Resource Key does not include crawler detection properties (<code>IsCrawler</code> or <code>CrawlerUsage</code>). Robots.txt enforcement will not work until you add these properties to your key at <a href="https://configure.51degrees.com/" target="_blank">configure.51degrees.com</a>.'
+    no_crawler: '<strong>Warning:</strong> Your Resource Key does not include crawler detection properties (<code>IsCrawler</code> or <code>CrawlerUsage</code>). Robots.txt enforcement will not work until you add these properties to your key at <a href="https://configure.51degrees.com/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=languages-robots-strings.yaml&utm_term=no_crawler" target="_blank">configure.51degrees.com</a>.'
     # (HTML) Shown when the resource key has IsCrawler but not CrawlerUsage.
-    no_crawler_usage: '<strong>Note:</strong> Your Resource Key includes <code>IsCrawler</code> but not <code>CrawlerUsage</code>. Without <code>CrawlerUsage</code>, category selections have no effect — enforcement falls back to path-based rules only. Upgrade your key at <a href="https://configure.51degrees.com/" target="_blank">configure.51degrees.com</a> for category-based enforcement.'
+    no_crawler_usage: '<strong>Note:</strong> Your Resource Key includes <code>IsCrawler</code> but not <code>CrawlerUsage</code>. Without <code>CrawlerUsage</code>, category selections have no effect — enforcement falls back to path-based rules only. Upgrade your key at <a href="https://configure.51degrees.com/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=languages-robots-strings.yaml&utm_term=no_crawler_usage" target="_blank">configure.51degrees.com</a> for category-based enforcement.'
     # (HTML) Shown when the resource key lacks RobotsTxt properties.
-    no_robots_txt: '<strong>Note:</strong> Your Resource Key does not include the RobotsTxt <code>PlainText</code> property. Robots.txt generation will use local rules only. Upgrade your key at <a href="https://configure.51degrees.com/" target="_blank">configure.51degrees.com</a>'
+    no_robots_txt: '<strong>Note:</strong> Your Resource Key does not include the RobotsTxt <code>PlainText</code> property. Robots.txt generation will use local rules only. Upgrade your key at <a href="https://configure.51degrees.com/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=languages-robots-strings.yaml&utm_term=no_robots_txt" target="_blank">configure.51degrees.com</a>'
     # Plain text. Shown after a successful Save and Generate action.
     generate_success: 'Robots.txt successfully generated from the 51Degrees Cloud API and cached.'
     # (HTML) Shown when the Cloud API call fails. %s is replaced by the error detail.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === 51Degrees ===
 
 Contributors: 51Degrees
-Donate link: https://51degrees.com/
+Donate link: https://51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.txt&utm_term=51degrees
 Tags: 51degrees, device detection, location, Google Analytics, device, detect, device type, smartphone, tablet, desktop, mobile, optimize, detection, customizable, personalized, tailored, targeting, responsive, mobile website, mobile friendly, user experience, ecommerce, OpenStreetMap, Digital element, Geolocation
 Requires at least: 4.7
 Tested up to: 6.9.1
@@ -15,7 +15,7 @@ The best plugin for WordPress to send Device properties as Custom Dimensions to 
 
 Integrating 51Degrees Device Detection with your website will allow you to make informed decisions about what content a user engages with and how it is displayed. Combining the information learned from your analytics data with real-time enhanced device data on your website will empower you to produce a page built for that specific device’s needs. Taking this one step further, you have an additional 280+ device properties available to enhance your user's user experience. The possibilities are endless as to what you can do with the information - it’s remarkably powerful.
 
-This plugin makes use of the 51Degrees Pipeline API to deliver various data intelligence [services](https://51degrees.com/services). You can also add custom dimensions to your Google Analytics solution which will enhance your analytical data. With 51Degrees you can capture data that Google Analytics doesn't readily collect, such as detailed information on specific device hardware.
+This plugin makes use of the 51Degrees Pipeline API to deliver various data intelligence [services](https://51degrees.com/services?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.txt&utm_term=description). You can also add custom dimensions to your Google Analytics solution which will enhance your analytical data. With 51Degrees you can capture data that Google Analytics doesn't readily collect, such as detailed information on specific device hardware.
 
 == Features ==
 
@@ -66,9 +66,9 @@ For instructions on how to install the plugin manually or by uploading a zip fil
 = After activation =
 
 1. Visit the new `51Degrees` Settings menu.
-2. To start using this plugin, you will need to create a `Resource Key`. This enables access to the data you need via the 51Degrees cloud service. You can create a `Resource Key` for free, using the [configurator](https://configure.51degrees.com/) to select the properties you want.
+2. To start using this plugin, you will need to create a `Resource Key`. This enables access to the data you need via the 51Degrees cloud service. You can create a `Resource Key` for free, using the [configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.txt&utm_term=after-activation) to select the properties you want.
 
-For a demo video on how to use our configurator, [click here](https://51degrees.com/documentation/_concepts__configurator.html).
+For a demo video on how to use our configurator, [click here](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.txt&utm_term=after-activation).
 
 = Integration with Google Analytics =
 
@@ -92,7 +92,7 @@ For a demo video on how to use our configurator, [click here](https://51degrees.
 
 = Is the 51Degrees plugin free? =
 
-The 51Degrees plugin is free and open source. However Our [Cloud Configurator](https://configure.51degrees.com/) contains both FREE and PAID properties. The properties you will need to pay for are shown with a dollar icon. You can buy what you need on our [Pricing page](https://51degrees.com/pricing).
+The 51Degrees plugin is free and open source. However Our [Cloud Configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.txt&utm_term=is-the-51degrees-plugin-free) contains both FREE and PAID properties. The properties you will need to pay for are shown with a dollar icon. You can buy what you need on our [Pricing page](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=pipeline-wordpress&utm_content=readme.txt&utm_term=is-the-51degrees-plugin-free).
 
 = What happens if I already use another plugin to integrate Google Analytics? =
 

--- a/setup.php
+++ b/setup.php
@@ -51,13 +51,13 @@
 
     <p>
         To get started visit
-        <a href="https://configure.51degrees.com/zHPMyDk6" target="_blank">the Configurator</a>
+        <a href="https://configure.51degrees.com/zHPMyDk6?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=setup.php&utm_term=body" target="_blank">the Configurator</a>
         to get a 51Degrees Resource Key for the device detection properties you
         want to get access to.
         </br>
         For more information on how to use our Configurator, view our explainer
         video
-        <a href="https://51degrees.com/documentation/_concepts__configurator.html" target="_blank">
+        <a href="https://51degrees.com/documentation/_concepts__configurator.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-wordpress&utm_content=setup.php&utm_term=body" target="_blank">
             here
         </a>.
     </p>


### PR DESCRIPTION
Apply the standard UTM vocabulary to navigational 51degrees.com and configure.51degrees.com links so the Content Team can trace traffic to its exact source.

Changes:
- README.md (github/readme): retagged logo (old varnish_open_source scheme) and developer documentation links, tagged the configurator link.
- readme.txt (treated as github/readme, see note): tagged Donate link, services, configurator, demo-video documentation, Cloud Configurator and Pricing links.
- ci/README.md (github/readme): tagged the resource-key documentation link, un-versioned the 4.4 path.
- fiftyonedegrees.php and includes/fiftyone-service.php: tagged the WordPress plugin-header Plugin URI and Author URI fields as packagist/package (term = field name).
- help.php and setup.php (code/comment): tagged user-visible admin-page documentation and configurator links (setup.php keeps its configure.51degrees.com share-key path zHPMyDk6 unchanged, query appended after it).
- includes/pipeline.php (code/comment): tagged the developer-reference blog link inside process().
- languages/common-strings.yaml and languages/robots-strings.yaml (code/comment): tagged configure.51degrees.com links inside runtime admin-notice messages, term = the message key per the MESSAGE LINKS rule (rejected, no_crawler, no_crawler_usage, no_robots_txt).
- Added .github/workflows/utm-link-lint.yml.

Judgement note: readme.txt is the WordPress plugin readme rendered on wordpress.org, so per spec its navigational links are treated as github/readme rather than packagist/package. The plugin-header URI fields, by contrast, are package metadata and are tagged packagist/package.

Left untouched: cloud.51degrees.com (functional host, also config data) in includes/cloud-metadata.php, includes/fiftyone-service.php, README.md; the engineering email in lib/composer.json; and test fixtures in tests/. No composer.json homepage field exists. Lint passes with scripts/utm-lint.ps1.