### PR TITLE
Fix #45: emit terms-of-service link elements in the HTML head section

### DIFF
--- a/includes/robots-txt.php
+++ b/includes/robots-txt.php
@@ -22,6 +22,7 @@ class FiftyOneDegreesRobotsTxt {
     public static function init() {
         add_filter('robots_txt', [__CLASS__, 'generate_robots_txt'], 10, 2);
         add_action('init', [__CLASS__, 'enforce_crawler_redirect'], 15);
+        add_action('wp_head', [__CLASS__, 'render_terms_of_service_links'], 10);
         add_action('fiftyonedegrees_refresh_robots_txt', [__CLASS__, 'refresh_robots_txt_cron']);
     }
 
@@ -220,6 +221,51 @@ class FiftyOneDegreesRobotsTxt {
         }
 
         return $content;
+    }
+
+    /**
+     * Extracts the Terms Document Locator (TDL) URLs from the robots.txt
+     * content this plugin serves. Standard TDLs are stored locally as
+     * macros and only resolved to URLs by 51Degrees Cloud, so the served
+     * robots.txt content (custom top + cloud plaintext + custom bottom)
+     * is the one place the final URLs exist. One URL per "tdl:" line,
+     * kept in order of first appearance with duplicates removed.
+     *
+     * @return array<int,string>
+     */
+    public static function get_tdl_urls_from_robots_txt() {
+        $content = self::generate_robots_txt_content(get_option('blog_public'));
+        $urls = [];
+        foreach (preg_split('/\r\n|\r|\n/', $content) as $line) {
+            if (preg_match('/^\s*tdl\s*:\s*(\S+)/i', $line, $matches)) {
+                if (!in_array($matches[1], $urls, true)) {
+                    $urls[] = $matches[1];
+                }
+            }
+        }
+        return $urls;
+    }
+
+    /**
+     * Echoes one <link rel="terms-of-service"> element into the HTML
+     * <head> section for each TDL present in the generated robots.txt,
+     * so pages advertise the same terms documents as the robots.txt.
+     * See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel#terms-of-service
+     *
+     * Runs on wp_head and emits nothing when the robots.txt feature is
+     * disabled or no TDLs are configured.
+     */
+    public static function render_terms_of_service_links() {
+        if (get_option(Options::ROBOTS_ENABLE, 'off') !== 'on') {
+            return;
+        }
+        foreach (self::get_tdl_urls_from_robots_txt() as $url) {
+            $escaped = esc_url($url);
+            if (empty($escaped)) {
+                continue;
+            }
+            echo '<link rel="terms-of-service" href="' . $escaped . '" />' . "\n";
+        }
     }
 
     public static function enforce_crawler_redirect() {

--- a/tests/RobotsTxtTests.php
+++ b/tests/RobotsTxtTests.php
@@ -1553,4 +1553,139 @@ class RobotsTxtTests extends TestCase {
         $this->assertStringContainsString('51Degrees', $logged[0]);
     }
 
+    // ------------------------------------------------------------------
+    // Terms-of-service <link> elements in the HTML <head> (issue #45)
+    // ------------------------------------------------------------------
+
+    /**
+     * Minimal stand-in for WordPress esc_url: passes http(s) URLs
+     * through and rejects anything else, mirroring the behaviour the
+     * production code relies on.
+     */
+    private function mockEscUrl() {
+        Functions\when('esc_url')->alias(function ($url) {
+            return preg_match('#^https?://#i', $url) ? $url : '';
+        });
+    }
+
+    private function renderTermsOfServiceLinks(): string {
+        ob_start();
+        FiftyOneDegreesRobotsTxt::render_terms_of_service_links();
+        return ob_get_clean();
+    }
+
+    public function testInitRegistersWpHeadTermsOfServiceAction() {
+        $added = [];
+        Functions\when('add_action')->alias(function ($hook, $callback) use (&$added) {
+            $added[] = [$hook, $callback];
+        });
+
+        FiftyOneDegreesRobotsTxt::init();
+
+        $found = false;
+        foreach ($added as $call) {
+            if ($call[0] === 'wp_head'
+                && is_array($call[1])
+                && $call[1][1] === 'render_terms_of_service_links') {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue(
+            $found,
+            'init() must register render_terms_of_service_links on wp_head'
+        );
+    }
+
+    public function testTermsOfServiceLinksNotEmittedWhenDisabled() {
+        $this->mockEscUrl();
+        $this->mockOptions([
+            Options::ROBOTS_ENABLE => 'off',
+            Options::ROBOTS_PLAINTEXT_CACHE => "tdl: https://example.com/terms/v1\n",
+        ]);
+
+        $this->assertSame('', $this->renderTermsOfServiceLinks());
+    }
+
+    public function testTermsOfServiceLinkEmittedPerTdlLine() {
+        $this->mockEscUrl();
+        $this->mockOptions([
+            Options::ROBOTS_ENABLE => 'on',
+            Options::ROBOTS_PLAINTEXT_CACHE =>
+                "User-agent: *\nDisallow: /private/\n"
+                . "tdl: https://m4ow.uk/socw/1.txt\n"
+                . "tdl: https://example.com/other/tos.txt\n",
+        ]);
+
+        $output = $this->renderTermsOfServiceLinks();
+
+        $this->assertSame(
+            '<link rel="terms-of-service" href="https://m4ow.uk/socw/1.txt" />' . "\n"
+            . '<link rel="terms-of-service" href="https://example.com/other/tos.txt" />' . "\n",
+            $output
+        );
+    }
+
+    public function testTermsOfServiceLinksIncludeCustomSectionsAndDeduplicate() {
+        $this->mockEscUrl();
+        $this->mockOptions([
+            Options::ROBOTS_ENABLE => 'on',
+            Options::ROBOTS_CUSTOM_TOP => "tdl: https://example.com/terms/v1",
+            Options::ROBOTS_PLAINTEXT_CACHE => "tdl: https://example.com/terms/v1\n",
+            Options::ROBOTS_CUSTOM_BOTTOM => "tdl: https://example.org/terms/v2",
+        ]);
+
+        $output = $this->renderTermsOfServiceLinks();
+
+        $this->assertSame(
+            '<link rel="terms-of-service" href="https://example.com/terms/v1" />' . "\n"
+            . '<link rel="terms-of-service" href="https://example.org/terms/v2" />' . "\n",
+            $output
+        );
+    }
+
+    public function testTermsOfServiceLinksNoOutputWithoutTdlLines() {
+        $this->mockEscUrl();
+        $this->mockOptions([
+            Options::ROBOTS_ENABLE => 'on',
+            Options::ROBOTS_PLAINTEXT_CACHE => "User-agent: *\nDisallow: /private/\n",
+        ]);
+
+        $this->assertSame('', $this->renderTermsOfServiceLinks());
+    }
+
+    public function testTermsOfServiceLinksSkipUrlsRejectedByEscUrl() {
+        $this->mockEscUrl();
+        $this->mockOptions([
+            Options::ROBOTS_ENABLE => 'on',
+            Options::ROBOTS_PLAINTEXT_CACHE =>
+                "tdl: javascript:alert(1)\n"
+                . "tdl: https://example.com/terms/v1\n",
+        ]);
+
+        $output = $this->renderTermsOfServiceLinks();
+
+        $this->assertSame(
+            '<link rel="terms-of-service" href="https://example.com/terms/v1" />' . "\n",
+            $output
+        );
+    }
+
+    public function testGetTdlUrlsFromRobotsTxtParsesCaseAndWhitespace() {
+        $this->mockOptions([
+            Options::ROBOTS_ENABLE => 'on',
+            Options::ROBOTS_PLAINTEXT_CACHE =>
+                "  TDL:   https://example.com/terms/v1\r\n"
+                . "tdl:https://example.org/terms/v2\n"
+                . "not-a-tdl: https://example.net/ignored\n",
+        ]);
+
+        $result = FiftyOneDegreesRobotsTxt::get_tdl_urls_from_robots_txt();
+
+        $this->assertSame(
+            ['https://example.com/terms/v1', 'https://example.org/terms/v2'],
+            $result
+        );
+    }
+
 }


### PR DESCRIPTION
Closes #45

> **Note.** This change was produced with AI assistance as part of a housekeeping sweep on 5th August 2026. It needs human review before merge.

## Problem

Issue [#45](https://github.com/51Degrees/pipeline-wordpress/issues/45) asks for the plugin to add `terms-of-service` `<link>` elements to the `<head>` section of every WordPress page when the robots.txt feature is active, with one element per Terms Document Locator (TDL) used in the robots.txt. The `terms-of-service` link relation is described on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel#terms-of-service). Before this change the plugin advertised TDLs only through the generated robots.txt, so HTML pages carried no machine-readable pointer to the same terms documents.

## What was checked and found

- `includes/robots-txt.php` holds the robots.txt feature. `FiftyOneDegreesRobotsTxt::init()` registers the `robots_txt` filter and related hooks, and `generate_robots_txt_content()` assembles the served robots.txt from the custom top text, the cached cloud-generated plaintext and the custom bottom text.
- `includes/standard-tdls.php` shows that standard TDL selections are stored locally as macros (for example `MOW-SOCW`), which are sent to the 51Degrees cloud service and resolved to real URLs server side. The locally stored settings therefore do not contain the final TDL URLs for standard entries. The resolved URLs exist only in the `tdl:` lines of the robots.txt content the plugin serves, which is also exactly the set the issue asks to mirror ("one element per TDL used in the robots.txt").
- `includes/ga-service.php` already registers a `wp_head` action for the analytics snippet, confirming `wp_head` as the plugin's established way to add head-section output.
- `tests/RobotsTxtTests.php` covers the robots.txt feature using Brain Monkey stubs, and `phpunit.xml` runs it in the default Unit suite.

## What was changed and why

All changes are in two files.

`includes/robots-txt.php`

- `init()` now also registers `render_terms_of_service_links` on the `wp_head` action at the default priority, alongside the existing hook registrations.
- New method `get_tdl_urls_from_robots_txt()` parses the same content `generate_robots_txt_content()` serves for robots.txt, extracting the URL from every `tdl:` line (case-insensitive, tolerant of surrounding whitespace) in order of first appearance with duplicates removed. Parsing the served content rather than the saved options means standard TDL macros, which only the cloud service can resolve to URLs, are picked up correctly, and any `tdl:` lines an admin adds through the custom top or bottom text are mirrored too, so the head section always matches the robots.txt exactly.
- New method `render_terms_of_service_links()` returns without output when the robots.txt feature is disabled (the same `Options::ROBOTS_ENABLE` gate the robots.txt filter uses), then echoes one `<link rel="terms-of-service" href="..." />` element per TDL URL. Each URL passes through the WordPress `esc_url()` function, and any URL `esc_url()` rejects is skipped rather than emitted empty.

`tests/RobotsTxtTests.php`

- Seven new unit tests covering hook registration, the disabled case, one element per `tdl:` line in the issue's exact expected format, deduplication across the custom top, cached and custom bottom sections, no output when no `tdl:` lines exist, skipping of URLs rejected by `esc_url()`, and parser tolerance for case and whitespace variations.

## Emitted markup, before and after

With the robots.txt feature enabled and a generated robots.txt containing:

```
tdl: https://m4ow.uk/socw/1.txt
tdl: https://example.com/other/tos.txt
```

Before this change the `<head>` section contained no terms-of-service elements. After this change every WordPress-generated page's `<head>` section additionally contains:

```html
<link rel="terms-of-service" href="https://m4ow.uk/socw/1.txt" />
<link rel="terms-of-service" href="https://example.com/other/tos.txt" />
```

When the robots.txt feature is off, or no TDLs are configured, nothing is emitted and the head output is unchanged.

## How it was verified

- `php -l` passes on both changed files.
- The full default PHPUnit Unit suite from `phpunit.xml` passes locally on PHP 8.5.1 with PHPUnit 9.6.35 after a `composer install` in `lib/`. All 439 tests with 861 assertions are green, which includes the 7 new tests (`tests/RobotsTxtTests.php` now has 89 tests).
- The hook path was also reasoned through by hand. `fiftyonedegrees.php` calls `FiftyOneDegreesRobotsTxt::init()` at plugin load, `init()` registers `render_terms_of_service_links` on `wp_head`, and WordPress themes call `wp_head()` inside `<head>`, so the elements land inside the head section of every themed page.

## What remains

- Human review of the approach, in particular the decision to parse the served robots.txt content for `tdl:` lines rather than read the saved TDL options, which was chosen because standard TDL macros are only resolved to URLs by the cloud service.
- A manual check on a live WordPress install that the elements appear in the rendered page source, since the automated tests exercise the hook callback directly rather than a full WordPress request.
- The issue's documentation note (that TDL and terms wording should no longer refer exclusively to robots.txt) touches product documentation outside this repository and is not addressed here.
